### PR TITLE
feature: frontend share management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4904,23 +4904,17 @@
 			"version": "7.11.2",
 			"resolved": "https://registry.npmjs.org/@types/pg/-/pg-7.11.2.tgz",
 			"integrity": "sha512-4+rj7fnidA77jFURNanuPPc1HrQv+RkhI6s+K18G9zOKbOUUpChA/rbNMqFukNuZ89LoIt/I9dAlxf329TjCNw==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*",
 				"@types/pg-types": "*"
-			}
-		},
-		"@types/pg-escape": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@types/pg-escape/-/pg-escape-0.2.0.tgz",
-			"integrity": "sha512-2kZMfZjnHSSCQxEhUQCKzIRFlrcjeGIxZ3qN0GMaWl8G/EyVq0qmRYK+UbziSsy+P/utTXP1b2KJ1Y2wxi45WA==",
-			"requires": {
-				"@types/node": "*"
 			}
 		},
 		"@types/pg-types": {
 			"version": "1.11.4",
 			"resolved": "https://registry.npmjs.org/@types/pg-types/-/pg-types-1.11.4.tgz",
 			"integrity": "sha512-WdIiQmE347LGc1Vq3Ki8sk3iyCuLgnccqVzgxek6gEHp2H0p3MQ3jniIHt+bRODXKju4kNQ+mp53lmP5+/9moQ==",
+			"dev": true,
 			"requires": {
 				"moment": ">=2.14.0"
 			}
@@ -19710,11 +19704,6 @@
 			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
 			"integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
 		},
-		"pg-escape": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/pg-escape/-/pg-escape-0.2.0.tgz",
-			"integrity": "sha1-ZVlMFpFlm0q24Mu/nVB0S+R0mY4="
-		},
 		"pg-int8": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -22378,17 +22367,6 @@
 			"integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
 			"requires": {
 				"xtend": "^4.0.0"
-			}
-		},
-		"postgres-schema-builder": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/postgres-schema-builder/-/postgres-schema-builder-1.0.1.tgz",
-			"integrity": "sha512-x6RlBm9juYUZwElwt3bnGJikkYhVtsGaXgAJmJyW4U8gVE33Tpub/REoqFHQxGza/X741dwZTaltw+M8XAFkrQ==",
-			"requires": {
-				"@types/pg": "^7.4.14",
-				"@types/pg-escape": "^0.2.0",
-				"pg": "^7.11.0",
-				"pg-escape": "^0.2.0"
 			}
 		},
 		"prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
 		"morgan": "^1.9.1",
 		"mp3-duration": "^1.1.0",
 		"pg": "^7.11.0",
-		"postgres-schema-builder": "^1.0.1",
 		"react": "^16.8.6",
 		"react-apollo": "^3.1.3",
 		"react-app-rewired": "^2.1.1",

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -23,5 +23,7 @@
 	"author": "Yannick Stachelscheid",
 	"license": "UNLICENSED",
 	"devDependencies": {},
-	"dependencies": {}
+	"dependencies": {
+		"postgres-schema-builder": "*"
+	}
 }

--- a/projects/backend/src/__test__/artist-service.test.ts
+++ b/projects/backend/src/__test__/artist-service.test.ts
@@ -28,7 +28,7 @@ afterAll(async () => {
 test('get artists for multiple shares', async () => {
 	const { artistService } = await setupTest({});
 
-	const shareIDs = [testData.shares.library_user1.share_id.toString(), testData.shares.some_shared_library.share_id.toString()];
+	const shareIDs = [testData.shares.library_user1.share_id.toString(), testData.shares.some_share.share_id.toString()];
 	const result = await artistService.getArtistsForShares(shareIDs);
 
 	expect(result).toIncludeAllMembers([

--- a/projects/backend/src/__test__/auth.test.ts
+++ b/projects/backend/src/__test__/auth.test.ts
@@ -401,7 +401,7 @@ describe('auth middleware', () => {
 
 describe('get permission from scope', () => {
 	const shareID1 = testData.shares.library_user1.share_id.toString();
-	const shareID2 = testData.shares.some_shared_library.share_id.toString();
+	const shareID2 = testData.shares.some_share.share_id.toString();
 	const shareID3 = testData.shares.library_user2.share_id.toString();
 	const scopes: Scopes = [
 		{ shareID: shareID1, permissions: ['playlist:create', 'playlist:modify', 'song:modify'] },

--- a/projects/backend/src/__test__/auth.test.ts
+++ b/projects/backend/src/__test__/auth.test.ts
@@ -326,7 +326,7 @@ describe('auth selectors', () => {
 describe('auth middleware', () => {
 	const makeContext = (context?: Partial<IGraphQLContext>): IGraphQLContext => ({
 		scopes: [],
-		services: { playlistService: null as any, shareService: null as any, songService: null as any },
+		services: {} as any,
 		userID: null,
 		...(context || {}),
 	});

--- a/projects/backend/src/__test__/auth.test.ts
+++ b/projects/backend/src/__test__/auth.test.ts
@@ -145,7 +145,7 @@ describe('express middleware', () => {
 });
 
 describe('native type-graphql auth middleware', () => {
-	const executeTestRequests = async (expressApp: express.Application, authToken: string | undefined, protectedSuccess?: boolean) => {
+	const executeTestRequests = async (expressApp: express.Application, authToken: string | undefined, protectedSuccess?: boolean, message?: string) => {
 		const publicQuery = `
 			query{
 				publicQuery(from: 1){message}
@@ -166,7 +166,7 @@ describe('native type-graphql auth middleware', () => {
 		} else {
 			expect(responseProtected.body).toMatchObject(makeGraphQLResponse(
 				null,
-				[{ message: `Access denied! You need to be authorized to perform this action!` }]
+				[{ message: message || `Access denied! You need to be authorized to perform this action!` }]
 			));
 		}
 
@@ -197,7 +197,7 @@ describe('native type-graphql auth middleware', () => {
 		const authTokenDecoded = await authService.verifyToken(authToken);
 		invalidAuthTokenStore.invalidate(authTokenDecoded.tokenID);
 
-		await executeTestRequests(expressApp, authToken, false);
+		await executeTestRequests(expressApp, authToken, false, 'AuthToken invalid');
 	});
 
 	test('no token', async () => {

--- a/projects/backend/src/__test__/genre-service.test.ts
+++ b/projects/backend/src/__test__/genre-service.test.ts
@@ -29,7 +29,7 @@ afterAll(async () => {
 test('get genres for multiple shares', async () => {
 	const { genreService } = await setupTest({});
 
-	const shareIDs = [testData.shares.library_user1.share_id.toString(), testData.shares.some_shared_library.share_id.toString()];
+	const shareIDs = [testData.shares.library_user1.share_id.toString(), testData.shares.some_share.share_id.toString()];
 	const result = await genreService.getGenresForShares(shareIDs);
 
 	expect(result).toBeArrayOfSize(defaultGenres.length * 2);

--- a/projects/backend/src/__test__/mocks/ShareServiceMock.ts
+++ b/projects/backend/src/__test__/mocks/ShareServiceMock.ts
@@ -39,4 +39,8 @@ export class ShareServiceMock implements IShareService {
 	public async delete(shareID: string): Promise<void> {
 		throw 'Not implemented yet';
 	}
+
+	public async removeUser(shareID: string, userID: string): Promise<void> {
+		throw 'Not implemented yet';
+	}
 }

--- a/projects/backend/src/__test__/playlist-resolver.test.ts
+++ b/projects/backend/src/__test__/playlist-resolver.test.ts
@@ -278,7 +278,7 @@ describe('add songs to playlist', () => {
 	})
 
 	test('linked song from share should succeed for shared playlist', async () => {
-		const shareID = testData.shares.some_shared_library.share_id
+		const shareID = testData.shares.some_share.share_id
 		const { graphQLServer, playlistService } = await setupTest({});
 		const { id: playlistID } = await playlistService.create(shareID, 'Some new shared playlist');
 		const songs = [testData.songs.song1_library_user1, testData.songs.song4_library_user2];
@@ -311,7 +311,7 @@ describe('add songs to playlist', () => {
 	})
 
 	test('foreign song from unrelated library should fail for shared playlist', async () => {
-		const shareID = testData.shares.some_shared_library.share_id
+		const shareID = testData.shares.some_share.share_id
 		const { graphQLServer, playlistService } = await setupTest({});
 		const { id: playlistID } = await playlistService.create(shareID, 'Some new shared playlist');
 		const songs = [testData.songs.song1_library_user1, testData.songs.song5_library_user3];

--- a/projects/backend/src/__test__/song-resolver.test.ts
+++ b/projects/backend/src/__test__/song-resolver.test.ts
@@ -226,7 +226,7 @@ describe('update song mutation', () => {
 			artists: ['Some new artist'],
 			tags: ['sometag'],
 		}
-		const shareID = testData.shares.some_shared_library.share_id;
+		const shareID = testData.shares.some_share.share_id;
 		const songID = testData.songs.song4_library_user2.song_id;
 		const query = makeUpdateSongMutation(shareID, songID, input);
 

--- a/projects/backend/src/__test__/song-type-service.test.ts
+++ b/projects/backend/src/__test__/song-type-service.test.ts
@@ -29,7 +29,7 @@ afterAll(async () => {
 test('get song types for multiple shares', async () => {
 	const { songTypeService } = await setupTest({});
 
-	const shareIDs = [testData.shares.library_user1.share_id.toString(), testData.shares.some_shared_library.share_id.toString()];
+	const shareIDs = [testData.shares.library_user1.share_id.toString(), testData.shares.some_share.share_id.toString()];
 	const result = await songTypeService.getSongTypesForShares(shareIDs);
 
 	expect(result).toBeArrayOfSize(defaultSongTypes.length * 2);

--- a/projects/backend/src/__test__/user-resolver.test.ts
+++ b/projects/backend/src/__test__/user-resolver.test.ts
@@ -118,7 +118,7 @@ describe('get users shares', () => {
 		expect(body).toEqual(makeGraphQLResponse({
 			viewer: {
 				...User.fromDBResult(testUser),
-				shares: [testData.shares.library_user1, testData.shares.some_shared_library].map(Share.fromDBResult)
+				shares: [testData.shares.library_user1, testData.shares.some_share].map(Share.fromDBResult)
 			}
 		}));
 	});

--- a/projects/backend/src/__test__/utils/setup-test-env.ts
+++ b/projects/backend/src/__test__/utils/setup-test-env.ts
@@ -101,5 +101,5 @@ export const setupTestSuite = () => {
 
 export const makeAllScopes = (): Scopes => [
 	{ shareID: testData.shares.library_user1.share_id.toString(), permissions: Permissions.ALL },
-	{ shareID: testData.shares.some_shared_library.share_id.toString(), permissions: Permissions.ALL },
+	{ shareID: testData.shares.some_share.share_id.toString(), permissions: Permissions.ALL },
 ];

--- a/projects/backend/src/auth/auth-middleware.ts
+++ b/projects/backend/src/auth/auth-middleware.ts
@@ -32,6 +32,7 @@ export const makeAuthExtractor = (authService: IAuthenticationService, invalidAu
 		} catch (err) {
 			if (err.name === 'TokenExpiredError') {
 				req.context.error = { statusCode: HTTPStatusCodes.UNAUTHORIZED, message: 'AuthToken expired' };
+
 				return next();
 			}
 			// istanbul ignore next

--- a/projects/backend/src/database/seed.ts
+++ b/projects/backend/src/database/seed.ts
@@ -175,7 +175,7 @@ export const testData: ITestDataSchema = {
 		},
 		user2: {
 			name: 'Simon',
-			email: faker.internet.email(),
+			email: 'simon@musicshare.de',
 			user_id: user2ID,
 			date_added: moment().subtract(3, 'hours').toDate(),
 			date_removed: null,
@@ -297,7 +297,13 @@ export const makeDatabaseSeed = ({ database, services }: IMakeDatabaseSeedArgs):
 				await shareService.create(shareByUser.user_ids[0], shareByUser.name, shareByUser.is_library, shareByUser.share_id);
 
 				for (const shareUserID of shareByUser.user_ids.slice(1)) {
-					await shareService.addUser(shareByUser.share_id, shareUserID, Permissions.ALL);
+					let permissions = Permissions.ALL;
+
+					if (shareByUser.share_id === someShareShareID && shareUserID === user2ID) {
+						permissions = Permissions.NEW_MEMBER;
+					}
+
+					await shareService.addUser(shareByUser.share_id, shareUserID, permissions);
 				}
 
 				await Promise.all(defaultSongTypes.map(songType =>

--- a/projects/backend/src/database/seed.ts
+++ b/projects/backend/src/database/seed.ts
@@ -15,7 +15,7 @@ import { Permissions } from '../auth/permissions';
 import { makeFileSourceJSONType } from '../models/FileSourceModels';
 
 type Users = 'user1' | 'user2' | 'user3';
-type Shares = 'library_user1' | 'library_user2' | 'some_shared_library' | 'some_unrelated_library' | 'some_unrelated_share';
+type Shares = 'library_user1' | 'library_user2' | 'some_share' | 'some_unrelated_library' | 'some_unrelated_share';
 type Songs = 'song1_library_user1' | 'song2_library_user1' | 'song3_library_user1' | 'song4_library_user2' | 'song5_library_user3';
 type Playlists = 'playlist1_library_user1' | 'playlist2_library_user1' | 'playlist_some_shared_library' | 'playlist_library_user2';
 
@@ -207,7 +207,7 @@ export const testData: ITestDataSchema = {
 			date_removed: null,
 			user_ids: [user2ID],
 		},
-		some_shared_library: {
+		some_share: {
 			share_id: someShareShareID,
 			name: 'Some Shared Library',
 			is_library: false,

--- a/projects/backend/src/database/seed.ts
+++ b/projects/backend/src/database/seed.ts
@@ -193,7 +193,7 @@ export const testData: ITestDataSchema = {
 	shares: {
 		library_user1: {
 			share_id: libraryUser1ShareID,
-			name: 'Share Yss',
+			name: 'Library Yss',
 			is_library: true,
 			date_added: moment().subtract(3, 'hours').toDate(),
 			date_removed: null,

--- a/projects/backend/src/inputs/ShareIDInput.ts
+++ b/projects/backend/src/inputs/ShareIDInput.ts
@@ -1,0 +1,9 @@
+import { InputType, Field } from "type-graphql";
+import { Length } from "class-validator";
+
+@InputType()
+export class ShareIDInput {
+	@Length(36, 36)
+	@Field(() => String)
+	public readonly shareID!: string;
+}

--- a/projects/backend/src/resolvers/ShareResolver.ts
+++ b/projects/backend/src/resolvers/ShareResolver.ts
@@ -15,6 +15,7 @@ import { User } from "../models/UserModel";
 import { AcceptInvitationInput } from "../inputs/AcceptInvitationInput";
 import { RevokeInvitationInput } from "../inputs/RevokeInvitationInput";
 import { expireAuthToken } from "../auth/auth-middleware";
+import { ShareIDInput } from "../inputs/ShareIDInput";
 
 @Resolver(of => Share)
 export class ShareResolver {
@@ -189,6 +190,17 @@ export class ShareResolver {
 		@Arg('input') { userID }: RevokeInvitationInput,
 	): Promise<boolean> {
 		await this.services.userService.revokeInvitation(userID)
+
+		return true
+	}
+
+	@Mutation(() => Boolean)
+	@ShareAuth()
+	public async leaveShare(
+		@Arg('input') { shareID }: ShareIDInput,
+		@Ctx() { userID }: IGraphQLContext,
+	): Promise<boolean> {
+		await this.services.shareService.removeUser(shareID, userID!)
 
 		return true
 	}

--- a/projects/backend/src/resolvers/ShareResolver.ts
+++ b/projects/backend/src/resolvers/ShareResolver.ts
@@ -137,6 +137,7 @@ export class ShareResolver {
 	@Mutation(() => Boolean)
 	public async deleteShare(
 		@Args() { shareID }: ShareIDArg,
+		@Ctx() ctx: IGraphQLContext,
 	): Promise<boolean> {
 		await this.services.shareService.delete(shareID)
 		await expireAuthToken(ctx)

--- a/projects/backend/src/resolvers/ShareResolver.ts
+++ b/projects/backend/src/resolvers/ShareResolver.ts
@@ -14,6 +14,7 @@ import { Permissions } from "../auth/permissions";
 import { User } from "../models/UserModel";
 import { AcceptInvitationInput } from "../inputs/AcceptInvitationInput";
 import { RevokeInvitationInput } from "../inputs/RevokeInvitationInput";
+import { expireAuthToken } from "../auth/auth-middleware";
 
 @Resolver(of => Share)
 export class ShareResolver {
@@ -112,7 +113,10 @@ export class ShareResolver {
 		@Args() { name }: ShareNameArg,
 		@Ctx() ctx: IGraphQLContext
 	): Promise<Share> {
-		return this.services.shareService.create(ctx.userID!, name, false);
+		const createdShare = await this.services.shareService.create(ctx.userID!, name, false)
+		await expireAuthToken(ctx)
+
+		return createdShare
 	}
 
 	@Authorized()
@@ -133,9 +137,9 @@ export class ShareResolver {
 	@Mutation(() => Boolean)
 	public async deleteShare(
 		@Args() { shareID }: ShareIDArg,
-
 	): Promise<boolean> {
 		await this.services.shareService.delete(shareID)
+		await expireAuthToken(ctx)
 
 		return true
 	}

--- a/projects/backend/src/services/ShareService.ts
+++ b/projects/backend/src/services/ShareService.ts
@@ -19,6 +19,7 @@ export interface IShareService {
 	rename(shareID: string, name: string): Promise<void>;
 	delete(shareID: string): Promise<void>;
 	addUser(shareID: string, userID: string, permissions: Permission[]): Promise<void>;
+	removeUser(shareID: string, userID: string): Promise<void>;
 }
 
 export class ShareService implements IShareService {
@@ -106,6 +107,12 @@ export class ShareService implements IShareService {
 				date_removed: null,
 			})
 		);
+	}
+
+	public async removeUser(shareID: string, userID: string): Promise<void> {
+		await this.database.query(
+			UserSharesTable.delete(['share_id_ref', 'user_id_ref'])([shareID, userID])
+		)
 	}
 
 	public async rename(shareID: string, name: string): Promise<void> {

--- a/projects/backend/src/types/context.ts
+++ b/projects/backend/src/types/context.ts
@@ -1,10 +1,7 @@
 import * as Express from 'express';
 import { Permission } from '../auth/permissions';
-import { IPlaylistService } from '../services/PlaylistService';
 import { ContextFunction } from 'apollo-server-core';
 import { ExpressContext } from 'apollo-server-express/dist/ApolloServer';
-import { ISongService } from '../services/SongService';
-import { IShareService } from '../services/ShareService';
 import { IServices } from '../services/services';
 import { Share } from '../models/ShareModel';
 
@@ -15,14 +12,11 @@ export interface IBaseContext {
 		statusCode: number;
 		message: string;
 	};
+	authToken?: string;
 }
 
 export interface IGraphQLContext extends IBaseContext {
-	services: {
-		playlistService: IPlaylistService;
-		songService: ISongService;
-		shareService: IShareService;
-	},
+	services: IServices,
 	share?: Share;
 }
 
@@ -36,14 +30,10 @@ export type Scopes = IShareScope[];
 export type ContextRequest = Express.Request & { context: IBaseContext };
 export type CustomRequestHandler = (req: ContextRequest, res: Express.Response, next: Express.NextFunction) => any;
 
-export const makeGraphQLContextProvider = ({ playlistService, songService, shareService }: IServices): ContextFunction<ExpressContext, IGraphQLContext> =>
+export const makeGraphQLContextProvider = (services: IServices): ContextFunction<ExpressContext, IGraphQLContext> =>
 	({ req }: { req: ContextRequest }): IGraphQLContext => {
 		return {
 			...req.context,
-			services: {
-				playlistService,
-				songService,
-				shareService,
-			}
+			services,
 		};
 	}

--- a/projects/frontend/src/Apollo.ts
+++ b/projects/frontend/src/Apollo.ts
@@ -39,6 +39,10 @@ const typeDefs = `
 		shareID: String!
 		userID: String!
 	}
+
+	type ShareIDInput {
+		shareID: String!
+	}
 `;
 
 const httpLink = new HttpLink({

--- a/projects/frontend/src/Apollo.ts
+++ b/projects/frontend/src/Apollo.ts
@@ -9,6 +9,7 @@ import { makeConfigFromEnv } from "./config";
 import { ISSUE_AUTH_TOKEN, IIssueAuthTokenData, IIssueAuthTokenVariables } from "./graphql/mutations/issue-auth-token";
 import { getRefreshToken } from "./graphql/client/queries/auth-token-query";
 import { promiseToObservable } from "./graphql/utils/promise-to-observable";
+import { history } from "./components/routing/history";
 
 const config = makeConfigFromEnv();
 
@@ -95,7 +96,7 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
 	for (const error of graphQLErrors) {
 		if (error.message === 'Access denied! You need to be authorized to perform this action!') {
 			if (window.location.pathname !== "/login") {
-				window.location.href = "/login";
+				history.push("/login")
 			}
 		} else if (error.extensions && error.extensions.code === 'UNAUTHENTICATED') {
 			return promiseToObservable(getNewAuthToken(client)())
@@ -112,7 +113,7 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
 					} else {
 						localStorage.removeItem('auth-token')
 
-						window.location.href = "/login";
+						history.push("/login")
 
 						return Observable.of()
 					}

--- a/projects/frontend/src/Apollo.ts
+++ b/projects/frontend/src/Apollo.ts
@@ -28,6 +28,16 @@ const typeDefs = `
 		label: String
 		tags: [String!]
 	}
+
+	type InviteToShareInput {
+		shareID: String!
+		email: String!
+	}
+
+	type RevokeInvitationInput {
+		shareID: String!
+		userID: String!
+	}
 `;
 
 const httpLink = new HttpLink({

--- a/projects/frontend/src/App.tsx
+++ b/projects/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ApolloProvider } from "react-apollo";
 import { ApolloProvider as ApolloProviderHooks } from "@apollo/react-hooks";
-import { BrowserRouter as Router } from "react-router-dom";
+import { Router } from "react-router-dom";
 import { client, cache } from "./Apollo";
 import { DndProvider } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
@@ -13,6 +13,7 @@ import { Routing } from "./components/routing/Routing";
 import { PlayerContext } from "./player/player-context";
 import { Player } from "./player/player";
 import { IPrimaryTheme } from "./types/Theme";
+import { history } from "./components/routing/history";
 
 const config = makeConfigFromEnv();
 
@@ -56,7 +57,7 @@ const App = () => {
 					<ConfigContext.Provider value={config}>
 						<PlayerContext.Provider value={player}>
 							<DndProvider backend={HTML5Backend}>
-								<Router>
+								<Router history={history}>
 									<Routing />
 								</Router>
 							</DndProvider>

--- a/projects/frontend/src/components/HeaderMenu.tsx
+++ b/projects/frontend/src/components/HeaderMenu.tsx
@@ -18,6 +18,7 @@ export const HeaderNavMenu = () => {
 	const match = useRouteMatch()
 	const { data, loading, error } = useShares();
 	const [showCreateShare, setShowCreateShare] = useState(false)
+	const [sharesSubmenuHovered, setSharesSubmenuHovered] = useState(false)
 
 	if (loading) {
 		return <Spin />;
@@ -56,8 +57,11 @@ export const HeaderNavMenu = () => {
 						<span className="submenu-title-wrapper">
 							<StyledIcon type="share-alt" />
 							Shares
-          			</span>
+          				</span>
 					}
+					style={{ width: sharesSubmenuHovered ? 250 : 140 }}
+					onTitleMouseEnter={() => setSharesSubmenuHovered(true)}
+					onTitleMouseLeave={() => setSharesSubmenuHovered(false)}
 				>
 					<ItemGroup key="shares:library" title="Library">
 						<Menu.Item key={`shares:${libraryShare.id}`}>
@@ -70,13 +74,14 @@ export const HeaderNavMenu = () => {
 					</ItemGroup>
 					<ItemGroup key="shares:own" title="Own Shares">
 						{otherShares.map((share) => (
-							<Menu.Item key={`shares:${share.id}`}>
+							<SubMenu key={`shares:${share.id}`} title={
 								<Link to={`/shares/${share.id}`}>
 									<Icon type="share-alt" />
-									{share.name}
+									<span style={{ color: 'rgba(0, 0, 0, 0.65)' }}>{share.name}</span>
 								</Link>
-								)}
-              				</Menu.Item>
+							}>
+								<Menu.Item key="share:submenu:edit">Settings</Menu.Item>
+							</SubMenu>
 						))}
 					</ItemGroup>
 					<ItemGroup key="shares:create" title="Create share">

--- a/projects/frontend/src/components/HeaderMenu.tsx
+++ b/projects/frontend/src/components/HeaderMenu.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { Menu, Icon, Spin } from "antd";
 import styled from "styled-components";
 import { Link, useParams, useRouteMatch } from "react-router-dom";
 import { useShares } from "../graphql/queries/shares-query";
 import { IShareRoute } from "../interfaces";
+import { CreateShareModal } from "./modals/CreateShareModal";
 
 const { SubMenu, ItemGroup, Item } = Menu;
 
@@ -16,6 +17,7 @@ export const HeaderNavMenu = () => {
 	const { shareID } = useParams<IShareRoute>()
 	const match = useRouteMatch()
 	const { data, loading, error } = useShares();
+	const [showCreateShare, setShowCreateShare] = useState(false)
 
 	if (loading) {
 		return <Spin />;
@@ -36,47 +38,56 @@ export const HeaderNavMenu = () => {
 	const selectedKeys = shareID && match && !match.path.startsWith('/all/') ? `shares:${shareID}` : 'shares:all'
 
 	return (
-		<Menu
-			style={{ marginLeft: "200px" }}
-			selectedKeys={[selectedKeys]}
-			mode="horizontal"
-		>
-			<Item key="shares:all">
-				<Link to={`/all`}>
-					<StyledIcon type="profile" />
-					All
-        		</Link>
-			</Item>
-			<SubMenu
-				key="shares:own"
-				title={
-					<span className="submenu-title-wrapper">
-						<StyledIcon type="share-alt" />
-						Shares
-          			</span>
-				}
+		<>
+			<Menu
+				style={{ marginLeft: "200px" }}
+				selectedKeys={[selectedKeys]}
+				mode="horizontal"
 			>
-				<ItemGroup key="shares:library" title="Library">
-					<Menu.Item key={`shares:${libraryShare.id}`}>
-						<Link to={`/shares/${libraryShare.id}`}>
-							<Icon type="share-alt" />
-							{libraryShare.name}
-						</Link>
-						)}
-              				</Menu.Item>
-				</ItemGroup>
-				<ItemGroup key="shares:own" title="Own Shares">
-					{otherShares.map((share) => (
-						<Menu.Item key={`shares:${share.id}`}>
-							<Link to={`/shares/${share.id}`}>
+				<Item key="shares:all">
+					<Link to={`/all`}>
+						<StyledIcon type="profile" />
+						All
+        		</Link>
+				</Item>
+				<SubMenu
+					key="shares:own"
+					title={
+						<span className="submenu-title-wrapper">
+							<StyledIcon type="share-alt" />
+							Shares
+          			</span>
+					}
+				>
+					<ItemGroup key="shares:library" title="Library">
+						<Menu.Item key={`shares:${libraryShare.id}`}>
+							<Link to={`/shares/${libraryShare.id}`}>
 								<Icon type="share-alt" />
-								{share.name}
+								{libraryShare.name}
 							</Link>
 							)}
               				</Menu.Item>
-					))}
-				</ItemGroup>
-			</SubMenu>
-		</Menu>
+					</ItemGroup>
+					<ItemGroup key="shares:own" title="Own Shares">
+						{otherShares.map((share) => (
+							<Menu.Item key={`shares:${share.id}`}>
+								<Link to={`/shares/${share.id}`}>
+									<Icon type="share-alt" />
+									{share.name}
+								</Link>
+								)}
+              				</Menu.Item>
+						))}
+					</ItemGroup>
+					<ItemGroup key="shares:create" title="Create share">
+						<Menu.Item key="shares:create:button" onClick={() => setShowCreateShare(true)}>
+							<Icon type="plus" />
+							Create share
+					</Menu.Item>
+					</ItemGroup>
+				</SubMenu>
+			</Menu>
+			{showCreateShare && <CreateShareModal onSubmit={() => setShowCreateShare(false)} onCancel={() => setShowCreateShare(false)} />}
+		</>
 	);
 };

--- a/projects/frontend/src/components/HeaderMenu.tsx
+++ b/projects/frontend/src/components/HeaderMenu.tsx
@@ -5,6 +5,8 @@ import { Link, useParams, useRouteMatch } from "react-router-dom";
 import { useShares } from "../graphql/queries/shares-query";
 import { IShareRoute } from "../interfaces";
 import { CreateShareModal } from "./modals/CreateShareModal";
+import { ShareSettings } from "./modals/share-settings/ShareSettings";
+import { IShare } from "../graphql/types";
 
 const { SubMenu, ItemGroup, Item } = Menu;
 
@@ -18,6 +20,7 @@ export const HeaderNavMenu = () => {
 	const match = useRouteMatch()
 	const { data, loading, error } = useShares();
 	const [showCreateShare, setShowCreateShare] = useState(false)
+	const [shareSettings, setShareSettings] = useState<IShare | null>(null)
 	const [sharesSubmenuHovered, setSharesSubmenuHovered] = useState(false)
 
 	if (loading) {
@@ -80,7 +83,7 @@ export const HeaderNavMenu = () => {
 									<span style={{ color: 'rgba(0, 0, 0, 0.65)' }}>{share.name}</span>
 								</Link>
 							}>
-								<Menu.Item key="share:submenu:edit">Settings</Menu.Item>
+								<Menu.Item key="share:submenu:edit" onClick={() => setShareSettings(share)}>Settings</Menu.Item>
 							</SubMenu>
 						))}
 					</ItemGroup>
@@ -93,6 +96,7 @@ export const HeaderNavMenu = () => {
 				</SubMenu>
 			</Menu>
 			{showCreateShare && <CreateShareModal onSubmit={() => setShowCreateShare(false)} onCancel={() => setShowCreateShare(false)} />}
+			{shareSettings && <ShareSettings share={shareSettings} onClose={() => setShareSettings(null)} />}
 		</>
 	);
 };

--- a/projects/frontend/src/components/modals/CreateShareModal.tsx
+++ b/projects/frontend/src/components/modals/CreateShareModal.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useState } from 'react'
 import { Modal } from 'antd'
 import { useCreateShare } from '../../graphql/mutations/create-share-mutation'
 import { Prompt } from './promt/Prompt'
+import { useHistory } from 'react-router-dom'
+import { IShare } from '../../graphql/types'
 
 interface ICreateShareModalProps {
 	onSubmit: () => void;
@@ -9,8 +11,13 @@ interface ICreateShareModalProps {
 }
 
 export const CreateShareModal: React.FC<ICreateShareModalProps> = ({ onSubmit, onCancel }) => {
+	const history = useHistory()
+	const onShareCreated = useCallback((share: IShare) => {
+		history.push(`/shares/${share.id}`)
+		onSubmit()
+	}, [history])
 	const [createShare] = useCreateShare({
-		onCompleted: onSubmit,
+		onCompleted: data => onShareCreated(data.createShare),
 	})
 	const [name, setName] = useState('')
 

--- a/projects/frontend/src/components/modals/CreateShareModal.tsx
+++ b/projects/frontend/src/components/modals/CreateShareModal.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useState } from 'react'
-import { Modal } from 'antd'
 import { useCreateShare } from '../../graphql/mutations/create-share-mutation'
 import { Prompt } from './promt/Prompt'
 import { useHistory } from 'react-router-dom'
@@ -15,7 +14,7 @@ export const CreateShareModal: React.FC<ICreateShareModalProps> = ({ onSubmit, o
 	const onShareCreated = useCallback((share: IShare) => {
 		history.push(`/shares/${share.id}`)
 		onSubmit()
-	}, [history])
+	}, [history, onSubmit])
 	const [createShare] = useCreateShare({
 		onCompleted: data => onShareCreated(data.createShare),
 	})

--- a/projects/frontend/src/components/modals/CreateShareModal.tsx
+++ b/projects/frontend/src/components/modals/CreateShareModal.tsx
@@ -1,0 +1,35 @@
+import React, { useCallback, useState } from 'react'
+import { Modal } from 'antd'
+import { useCreateShare } from '../../graphql/mutations/create-share-mutation'
+import { Prompt } from './promt/Prompt'
+
+interface ICreateShareModalProps {
+	onSubmit: () => void;
+	onCancel: () => void;
+}
+
+export const CreateShareModal: React.FC<ICreateShareModalProps> = ({ onSubmit, onCancel }) => {
+	const [createShare] = useCreateShare({
+		onCompleted: onSubmit,
+	})
+	const [name, setName] = useState('')
+
+	const onCreateShare = useCallback(() => {
+		createShare({
+			variables: { name },
+		})
+	}, [createShare, name])
+
+	return (
+		<Prompt
+			onChange={e => setName(e.target.value)}
+			onSubmit={onCreateShare}
+			onCancel={onCancel}
+			title="Create new share"
+			label="Share name"
+			placeholder="Some new share"
+			value={name}
+			validationError={name.trim().length < 2 ? 'Min. 2 characters' : undefined}
+		/>
+	)
+}

--- a/projects/frontend/src/components/modals/promt/Prompt.tsx
+++ b/projects/frontend/src/components/modals/promt/Prompt.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Input } from 'antd';
+import { Modal, Input, Form } from 'antd';
 
 interface IPromptProps {
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -8,11 +8,13 @@ interface IPromptProps {
 	okText?: string;
 	cancelText?: string;
 	title: string;
+	label?: string;
 	placeholder?: string;
 	value: string;
+	validationError?: string;
 }
 
-export const Prompt = ({ onSubmit, onCancel, okText, cancelText, title, placeholder, onChange, value }: IPromptProps) => (
+export const Prompt = ({ onSubmit, onCancel, okText, cancelText, title, placeholder, onChange, value, label, validationError }: IPromptProps) => (
 	<Modal
 		title={title}
 		visible={true}
@@ -21,11 +23,19 @@ export const Prompt = ({ onSubmit, onCancel, okText, cancelText, title, placehol
 		okText={okText}
 		cancelText={cancelText}
 	>
-		<Input
-			value={value}
-			type="text"
-			onChange={onChange}
-			placeholder={placeholder}
-		/>
+		<Form>
+			<Form.Item
+				label={label}
+				validateStatus={validationError ? 'error' : 'success'}
+			>
+				<Input
+					value={value}
+					type="text"
+					onChange={onChange}
+					placeholder={placeholder}
+
+				/>
+			</Form.Item>
+		</Form>
 	</Modal>
 );

--- a/projects/frontend/src/components/modals/promt/Prompt.tsx
+++ b/projects/frontend/src/components/modals/promt/Prompt.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Modal, Input, Form } from 'antd';
 
 interface IPromptProps {
-	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	onSubmit: () => any;
 	onCancel: () => any;
 	okText?: string;

--- a/projects/frontend/src/components/modals/share-settings/ShareSettings.tsx
+++ b/projects/frontend/src/components/modals/share-settings/ShareSettings.tsx
@@ -9,6 +9,7 @@ import { useInviteToShare } from '../../../graphql/mutations/invite-to-share-mut
 import { Typography } from 'antd';
 import { ApolloError } from 'apollo-client'
 import { useRevokeInvitation } from '../../../graphql/mutations/revoke-invitation-mutation'
+import { useRenameShare } from '../../../graphql/mutations/rename-share-mutation'
 
 const { Text } = Typography;
 
@@ -31,20 +32,26 @@ export const ShareSettings: React.FC<IShareSettingsProps> = ({ share, onClose })
 			width={800}
 		>
 			<Form>
-				{canChangeName && <ChangeSongName name={share.name} />}
+				{canChangeName && <ChangeSongName share={share} />}
 				{canInvite && <ShareUsers shareID={share.id} />}
 			</Form>
 		</Modal>
 	)
 }
 
-const ChangeSongName: React.FC<{ name: string }> = ({ name }) => {
+const ChangeSongName: React.FC<{ share: IShare}> = ({ share: {name, id} }) => {
 	const [shareName, setShareName] = useState(name)
 	const [debouncedShareName] = useDebounce(shareName, 1000)
+	const [renameShare] = useRenameShare()
 
 	useEffect(() => {
-		console.log('Change name')
-	}, [debouncedShareName])
+		renameShare({
+			variables: {
+				shareID: id,
+				name: debouncedShareName,
+			}
+		})
+	}, [debouncedShareName, id])
 
 	return (
 		<Form.Item

--- a/projects/frontend/src/components/modals/share-settings/ShareSettings.tsx
+++ b/projects/frontend/src/components/modals/share-settings/ShareSettings.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useDebugValue, useEffect, useCallback, useMemo } from 'react'
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { Modal, Form, Input, Table, Button, Alert, Popconfirm, Icon } from 'antd'
 import { IShare, IUser } from '../../../graphql/types'
 import { useDebounce } from 'use-debounce/lib'
 import { useShareUsers } from '../../../graphql/queries/share-users-query'
-import { ColumnProps } from 'antd/lib/table'
 import Column from 'antd/lib/table/Column'
 import { useInviteToShare } from '../../../graphql/mutations/invite-to-share-mutation'
 import { Typography } from 'antd';
@@ -37,7 +36,7 @@ export const ShareSettings: React.FC<IShareSettingsProps> = ({ share, onClose })
 		} else {
 			leaveShare(share.id)
 		}
-	}, [isOwner, share.id])
+	}, [isOwner, share.id, deleteShare, leaveShare])
 
 	const cancelButton = (
 		<Popconfirm
@@ -82,7 +81,7 @@ const ChangeSongName: React.FC<{ share: IShare }> = ({ share: { name, id } }) =>
 				name: debouncedShareName,
 			}
 		})
-	}, [debouncedShareName, id])
+	}, [debouncedShareName, id, renameShare])
 
 	return (
 		<Form.Item

--- a/projects/frontend/src/components/modals/share-settings/ShareSettings.tsx
+++ b/projects/frontend/src/components/modals/share-settings/ShareSettings.tsx
@@ -11,6 +11,7 @@ import { ApolloError } from 'apollo-client'
 import { useRevokeInvitation } from '../../../graphql/mutations/revoke-invitation-mutation'
 import { useRenameShare } from '../../../graphql/mutations/rename-share-mutation'
 import { useDeleteShare } from '../../../graphql/mutations/delete-share-mutation'
+import { useLeaveShare } from '../../../graphql/mutations/leave-share-mutation'
 
 const { Text } = Typography;
 
@@ -23,6 +24,9 @@ export const ShareSettings: React.FC<IShareSettingsProps> = ({ share, onClose })
 	const [deleteShare] = useDeleteShare({
 		onCompleted: () => onClose(),
 	})
+	const [leaveShare] = useLeaveShare({
+		onCompleted: () => onClose(),
+	})
 	const isOwner = useMemo(() => share.userPermissions.includes('share:owner'), [share.userPermissions])
 	const canChangeName = isOwner
 	const canInvite = isOwner
@@ -31,9 +35,9 @@ export const ShareSettings: React.FC<IShareSettingsProps> = ({ share, onClose })
 		if (isOwner) {
 			deleteShare(share.id)
 		} else {
-			// TODO, requires leaveShare backend mutation
+			leaveShare(share.id)
 		}
-	}, [isOwner])
+	}, [isOwner, share.id])
 
 	const cancelButton = (
 		<Popconfirm
@@ -43,8 +47,7 @@ export const ShareSettings: React.FC<IShareSettingsProps> = ({ share, onClose })
 		>
 			<Button
 				type="danger"
-				style={{ display: isOwner ? 'inline-block' : 'none' }}
-			>{isOwner ? 'Delete Share' : 'Leavle Share'}</Button>
+			>{isOwner ? 'Delete Share' : 'Leave Share'}</Button>
 		</Popconfirm>
 	)
 

--- a/projects/frontend/src/components/modals/share-settings/ShareSettings.tsx
+++ b/projects/frontend/src/components/modals/share-settings/ShareSettings.tsx
@@ -1,10 +1,16 @@
-import React, { useState, useDebugValue, useEffect } from 'react'
-import { Modal, Form, Input, Table, Button } from 'antd'
+import React, { useState, useDebugValue, useEffect, useCallback } from 'react'
+import { Modal, Form, Input, Table, Button, Alert } from 'antd'
 import { IShare, IUser } from '../../../graphql/types'
 import { useDebounce } from 'use-debounce/lib'
 import { useShareUsers } from '../../../graphql/queries/share-users-query'
 import { ColumnProps } from 'antd/lib/table'
 import Column from 'antd/lib/table/Column'
+import { useInviteToShare } from '../../../graphql/mutations/invite-to-share-mutation'
+import { Typography } from 'antd';
+import { ApolloError } from 'apollo-client'
+import { useRevokeInvitation } from '../../../graphql/mutations/revoke-invitation-mutation'
+
+const { Text } = Typography;
 
 interface IShareSettingsProps {
 	share: IShare;
@@ -56,27 +62,80 @@ const ChangeSongName: React.FC<{ name: string }> = ({ name }) => {
 }
 
 const ShareUsers: React.FC<{ shareID: string }> = ({ shareID }) => {
-	const { data: users, loading, error } = useShareUsers(shareID)
+	const { data: users, loading, error, refetch } = useShareUsers(shareID)
 	const [email, setEMail] = useState('')
+	const [invitationLink, setInvitationLink] = useState<string | null>(null)
+	const [inviteError, setInviteError] = useState<ApolloError | null>(null)
+	const [inviteToShare] = useInviteToShare({
+		onCompleted: (data) => {
+			if (data.inviteToShare !== null) {
+				setInvitationLink(data.inviteToShare)
+			}
 
-	if (loading) return <div>Loading</div>
+			setEMail('')
+			refetch()
+		},
+		onError: setInviteError,
+	})
+	const [revokeInvitation] = useRevokeInvitation({
+		onCompleted: () => refetch(),
+	})
+
+	const onInviteClick = useCallback(() => {
+		inviteToShare({
+			variables: {
+				input: {
+					shareID,
+					email,
+				}
+			}
+		})
+	}, [inviteToShare, shareID, email])
+
+	const onRevokeInvitationClick = useCallback((userID: string) => {
+		revokeInvitation({
+			variables: {
+				input: {
+					shareID,
+					userID,
+				}
+			}
+		})
+	}, [revokeInvitation, shareID])
+
 	if (error) return <div>Error</div>
 
 	return (
 		<>
 			<Form.Item label="Members">
-				<Table dataSource={users || []} pagination={false}>
+				<Table dataSource={users || []} pagination={false} loading={loading} scroll={{ y: 300 }}>
 					<Column title="Name" dataIndex="name" key="name" />
 					<Column title="E-Mail" dataIndex="email" key="email" />
 					<Column title="Status" dataIndex="status" key="status" />
 					<Column title="Permissions" dataIndex="permissions" key="permission" />
 					<Column title="Actions" key="actions" render={(text, user: IUser) => (
 						<>
-							{user.status === 'pending' && <Button type="link">Revoke</Button>}
+							{user.status === 'pending' && <Button type="link" onClick={() => onRevokeInvitationClick(user.id)}>Revoke</Button>}
 						</>
 					)} />
 				</Table>
 			</Form.Item>
+			{invitationLink && (
+				<Alert
+					message={<><span>Invitation link: </span><Text code>{invitationLink}</Text></>}
+					type="success"
+					closable
+					onClose={() => setInvitationLink(null)}
+				/>
+			)}
+			{inviteError && (
+				<Alert
+					message={inviteError.message.replace('GraphQL error: ', '')}
+					type="error"
+					closable
+					onClose={() => setInviteError(null)}
+				/>
+			)}
 			<Form.Item label="E-Mail">
 				<Input
 					value={email}
@@ -85,7 +144,7 @@ const ShareUsers: React.FC<{ shareID: string }> = ({ shareID }) => {
 					placeholder="example@domain.com"
 					width={300}
 				/>
-				<Button type="dashed">Invite</Button>
+				<Button type="dashed" onClick={onInviteClick}>Invite</Button>
 			</Form.Item>
 		</>
 	)

--- a/projects/frontend/src/components/modals/share-settings/ShareSettings.tsx
+++ b/projects/frontend/src/components/modals/share-settings/ShareSettings.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useDebugValue, useEffect } from 'react'
+import { Modal, Form, Input, Table, Button } from 'antd'
+import { IShare, IUser } from '../../../graphql/types'
+import { useDebounce } from 'use-debounce/lib'
+import { useShareUsers } from '../../../graphql/queries/share-users-query'
+import { ColumnProps } from 'antd/lib/table'
+import Column from 'antd/lib/table/Column'
+
+interface IShareSettingsProps {
+	share: IShare;
+	onClose: () => void;
+}
+
+export const ShareSettings: React.FC<IShareSettingsProps> = ({ share, onClose }) => {
+	const canChangeName = share.userPermissions.includes('share:owner')
+	const canInvite = share.userPermissions.includes('share:owner')
+
+	return (
+		<Modal
+			okText="OK"
+			cancelButtonProps={{ style: { display: 'none' } }}
+			onOk={onClose}
+			onCancel={onClose}
+			visible={true}
+			width={800}
+		>
+			<Form>
+				{canChangeName && <ChangeSongName name={share.name} />}
+				{canInvite && <ShareUsers shareID={share.id} />}
+			</Form>
+		</Modal>
+	)
+}
+
+const ChangeSongName: React.FC<{ name: string }> = ({ name }) => {
+	const [shareName, setShareName] = useState(name)
+	const [debouncedShareName] = useDebounce(shareName, 1000)
+
+	useEffect(() => {
+		console.log('Change name')
+	}, [debouncedShareName])
+
+	return (
+		<Form.Item
+			label="Name"
+			validateStatus={shareName.trim().length <= 2 ? 'error' : 'success'}
+		>
+			<Input
+				value={shareName}
+				type="text"
+				onChange={e => setShareName(e.target.value)}
+				placeholder="Share name"
+			/>
+		</Form.Item>
+	)
+}
+
+const ShareUsers: React.FC<{ shareID: string }> = ({ shareID }) => {
+	const { data: users, loading, error } = useShareUsers(shareID)
+	const [email, setEMail] = useState('')
+
+	if (loading) return <div>Loading</div>
+	if (error) return <div>Error</div>
+
+	return (
+		<>
+			<Form.Item label="Members">
+				<Table dataSource={users || []} pagination={false}>
+					<Column title="Name" dataIndex="name" key="name" />
+					<Column title="E-Mail" dataIndex="email" key="email" />
+					<Column title="Status" dataIndex="status" key="status" />
+					<Column title="Permissions" dataIndex="permissions" key="permission" />
+					<Column title="Actions" key="actions" render={(text, user: IUser) => (
+						<>
+							{user.status === 'pending' && <Button type="link">Revoke</Button>}
+						</>
+					)} />
+				</Table>
+			</Form.Item>
+			<Form.Item label="E-Mail">
+				<Input
+					value={email}
+					type="email"
+					onChange={e => setEMail(e.target.value)}
+					placeholder="example@domain.com"
+					width={300}
+				/>
+				<Button type="dashed">Invite</Button>
+			</Form.Item>
+		</>
+	)
+}

--- a/projects/frontend/src/components/routing/history.ts
+++ b/projects/frontend/src/components/routing/history.ts
@@ -1,0 +1,5 @@
+const createBrowserHistory = require("history").createBrowserHistory
+
+const browserHistory = createBrowserHistory()
+
+export const history = browserHistory

--- a/projects/frontend/src/graphql/hook-types.ts
+++ b/projects/frontend/src/graphql/hook-types.ts
@@ -1,0 +1,3 @@
+export interface IMutationOptions<TData = unknown> {
+	onCompleted?: (data: TData) => any;
+}

--- a/projects/frontend/src/graphql/hook-types.ts
+++ b/projects/frontend/src/graphql/hook-types.ts
@@ -1,3 +1,6 @@
+import { ApolloError } from "apollo-client";
+
 export interface IMutationOptions<TData = unknown> {
 	onCompleted?: (data: TData) => any;
+	onError?: (error: ApolloError) => any;
 }

--- a/projects/frontend/src/graphql/mutations/create-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/create-share-mutation.ts
@@ -1,0 +1,56 @@
+import { IShare, shareKeys } from "../types";
+import gql from "graphql-tag";
+import { useMutation } from "react-apollo";
+import { IMutationOptions } from "../hook-types";
+import { useCallback } from "react";
+import { MutationUpdaterFn } from "apollo-client";
+import { IGetSharesData, IGetSharesVariables, GET_SHARES } from "../queries/shares-query";
+
+interface ICreateShareVariables {
+	name: string;
+}
+
+interface ICreateShareData {
+	createShare: IShare;
+}
+
+const CREATE_SHARE = gql`
+	mutation CreateShare($name: String!) {
+		createShare(name: $name) {
+			${shareKeys}
+		}
+	}
+`
+
+export const useCreateShare = (opts?: IMutationOptions<ICreateShareData>) => {
+	const updateSharesCache = useCallback<MutationUpdaterFn<ICreateShareData>>((cache, { data }) => {
+		if (!data) return
+
+		const currentData = cache.readQuery<IGetSharesData, IGetSharesVariables>({
+			query: GET_SHARES,
+		})!
+
+		const { createShare: newShare } = data
+
+		cache.writeQuery<IGetSharesData, IGetSharesVariables>({
+			query: GET_SHARES,
+			data: {
+				viewer: {
+					id: currentData.viewer.id,
+					__typename: 'User',
+					shares: currentData.viewer.shares.concat({
+						...newShare,
+						__typename: 'Share',
+					})
+				}
+			}
+		})
+	}, [])
+
+	const hook = useMutation<ICreateShareData, ICreateShareVariables>(CREATE_SHARE, {
+		update: updateSharesCache,
+		...(opts || {}),
+	})
+
+	return hook
+}

--- a/projects/frontend/src/graphql/mutations/delete-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/delete-share-mutation.ts
@@ -39,13 +39,13 @@ export const useDeleteShare = (opts?: IMutationOptions<IDeleteShareData>) => {
 		})
 	}, [])
 
-	const [deleteShareMutation, other] = useMutation<IDeleteShareData, IDeleteShareVariables>(DELETE_SHARE)
+	const [deleteShareMutation, other] = useMutation<IDeleteShareData, IDeleteShareVariables>(DELETE_SHARE, opts)
 
 	const deleteShare = useCallback((shareID: string) => {
+
 		deleteShareMutation({
 			variables: { shareID },
 			update: makeUpdateSharesCache(shareID),
-			...(opts || {}),
 		})
 	}, [deleteShareMutation, opts])
 

--- a/projects/frontend/src/graphql/mutations/delete-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/delete-share-mutation.ts
@@ -1,0 +1,53 @@
+import gql from "graphql-tag";
+import { useMutation, MutationResult } from "react-apollo";
+import { IMutationOptions } from "../hook-types";
+import { useCallback } from "react";
+import { MutationUpdaterFn } from "apollo-client";
+import { IGetSharesData, IGetSharesVariables, GET_SHARES } from "../queries/shares-query";
+
+interface IDeleteShareData {
+	deleteShare: boolean;
+}
+
+interface IDeleteShareVariables {
+	shareID: string;
+}
+
+const DELETE_SHARE = gql`
+	mutation DeleteShare($shareID: String!) {
+		deleteShare(shareID: $shareID)
+	}
+`
+
+export const useDeleteShare = (opts?: IMutationOptions<IDeleteShareData>) => {
+	const makeUpdateSharesCache = useCallback((shareID: string): MutationUpdaterFn<IDeleteShareData> => (cache, { data, }) => {
+		if (!data) return
+
+		const currentData = cache.readQuery<IGetSharesData, IGetSharesVariables>({
+			query: GET_SHARES,
+		})!
+
+		cache.writeQuery<IGetSharesData, IGetSharesVariables>({
+			query: GET_SHARES,
+			data: {
+				viewer: {
+					id: currentData.viewer.id,
+					__typename: 'User',
+					shares: currentData.viewer.shares.filter(share => share.id !== shareID)
+				}
+			}
+		})
+	}, [])
+
+	const [deleteShareMutation, other] = useMutation<IDeleteShareData, IDeleteShareVariables>(DELETE_SHARE)
+
+	const deleteShare = useCallback((shareID: string) => {
+		deleteShareMutation({
+			variables: { shareID },
+			update: makeUpdateSharesCache(shareID),
+			...(opts || {}),
+		})
+	}, [deleteShareMutation])
+
+	return [deleteShare, other] as [(shareID: string) => void, MutationResult<IDeleteShareData>]
+}

--- a/projects/frontend/src/graphql/mutations/delete-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/delete-share-mutation.ts
@@ -47,7 +47,7 @@ export const useDeleteShare = (opts?: IMutationOptions<IDeleteShareData>) => {
 			update: makeUpdateSharesCache(shareID),
 			...(opts || {}),
 		})
-	}, [deleteShareMutation])
+	}, [deleteShareMutation, opts])
 
 	return [deleteShare, other] as [(shareID: string) => void, MutationResult<IDeleteShareData>]
 }

--- a/projects/frontend/src/graphql/mutations/delete-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/delete-share-mutation.ts
@@ -47,7 +47,7 @@ export const useDeleteShare = (opts?: IMutationOptions<IDeleteShareData>) => {
 			variables: { shareID },
 			update: makeUpdateSharesCache(shareID),
 		})
-	}, [deleteShareMutation, opts])
+	}, [deleteShareMutation, makeUpdateSharesCache])
 
 	return [deleteShare, other] as [(shareID: string) => void, MutationResult<IDeleteShareData>]
 }

--- a/projects/frontend/src/graphql/mutations/invite-to-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/invite-to-share-mutation.ts
@@ -1,0 +1,26 @@
+import gql from "graphql-tag";
+import { useMutation } from "react-apollo";
+import { IMutationOptions } from "../hook-types";
+
+interface IInviteToShareData {
+	inviteToShare: string | null;
+}
+
+interface IInviteToShareVariables {
+	input: {
+		shareID: string;
+		email: string;
+	}
+}
+
+const INVITE_TO_SHARE = gql`
+	mutation InviteToShare($input: InviteToShareInput!) {
+		inviteToShare(input: $input)
+	}
+`
+
+export const useInviteToShare = (opts?: IMutationOptions<IInviteToShareData>) => {
+	const hook = useMutation<IInviteToShareData, IInviteToShareVariables>(INVITE_TO_SHARE, opts)
+
+	return hook
+}

--- a/projects/frontend/src/graphql/mutations/leave-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/leave-share-mutation.ts
@@ -49,7 +49,7 @@ export const useLeaveShare = (opts?: IMutationOptions<ILeaveShareData>) => {
 			variables: { input: { shareID } },
 			update: makeUpdateSharesCache(shareID),
 		})
-	}, [leaveShareMutation, opts])
+	}, [leaveShareMutation, makeUpdateSharesCache])
 
 	return [leaveShare, other] as [(shareID: string) => void, MutationResult<ILeaveShareData>]
 }

--- a/projects/frontend/src/graphql/mutations/leave-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/leave-share-mutation.ts
@@ -1,0 +1,55 @@
+import gql from "graphql-tag";
+import { useCallback } from "react";
+import { MutationUpdaterFn } from "apollo-client";
+import { IGetSharesData, IGetSharesVariables, GET_SHARES } from "../queries/shares-query";
+import { useMutation, MutationResult } from "react-apollo";
+import { IMutationOptions } from "../hook-types";
+
+interface ILeaveShareData {
+	leaveShare: boolean;
+}
+
+interface ILeaveShareVariables {
+	input: {
+		shareID: string;
+	}
+}
+
+const LEAVE_SHARE = gql`
+	mutation LeaveShare($input: ShareIDInput!) {
+		leaveShare(input: $input)
+	}
+`
+
+export const useLeaveShare = (opts?: IMutationOptions<ILeaveShareData>) => {
+	const makeUpdateSharesCache = useCallback((shareID: string): MutationUpdaterFn<ILeaveShareData> => (cache, { data, }) => {
+		if (!data) return
+
+		const currentData = cache.readQuery<IGetSharesData, IGetSharesVariables>({
+			query: GET_SHARES,
+		})!
+
+		cache.writeQuery<IGetSharesData, IGetSharesVariables>({
+			query: GET_SHARES,
+			data: {
+				viewer: {
+					id: currentData.viewer.id,
+					__typename: 'User',
+					shares: currentData.viewer.shares.filter(share => share.id !== shareID)
+				}
+			}
+		})
+	}, [])
+
+	const [leaveShareMutation, other] = useMutation<ILeaveShareData, ILeaveShareVariables>(LEAVE_SHARE, opts)
+
+	const leaveShare = useCallback((shareID: string) => {
+
+		leaveShareMutation({
+			variables: { input: { shareID } },
+			update: makeUpdateSharesCache(shareID),
+		})
+	}, [leaveShareMutation, opts])
+
+	return [leaveShare, other] as [(shareID: string) => void, MutationResult<ILeaveShareData>]
+}

--- a/projects/frontend/src/graphql/mutations/rename-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/rename-share-mutation.ts
@@ -1,0 +1,27 @@
+import gql from "graphql-tag";
+import { useMutation } from "react-apollo";
+import { IMutationOptions } from "../hook-types";
+import { IShare, shareKeys } from "../types";
+
+interface IRenameShareData {
+	renameShare: IShare;
+}
+
+interface IRenameShareVariables {
+	name: string;
+	shareID: string;
+}
+
+const RENAME_SHARE = gql`
+	mutation RenameShare($name: String! $shareID: String!) {
+		renameShare(name: $name shareID: $shareID) {
+			${shareKeys}
+		}
+	}
+`
+
+export const useRenameShare = (opts?: IMutationOptions<IRenameShareData>) => {
+	const hook = useMutation<IRenameShareData, IRenameShareVariables>(RENAME_SHARE, opts)
+
+	return hook
+}

--- a/projects/frontend/src/graphql/mutations/revoke-invitation-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/revoke-invitation-mutation.ts
@@ -1,0 +1,26 @@
+import gql from "graphql-tag";
+import { IMutationOptions } from "../hook-types";
+import { useMutation } from "react-apollo";
+
+interface IRevokeInvitationData {
+	revokeInvitation: boolean;
+}
+
+interface IRevokeInvitationVariables {
+	input: {
+		shareID: string;
+		userID: string;
+	}
+}
+
+const REVOKE_INVITATION = gql`
+	mutation RevokeInvitation($input: RevokeInvitationInput!) {
+		revokeInvitation(input: $input)
+	}
+`
+
+export const useRevokeInvitation = (opts?: IMutationOptions<IRevokeInvitationData>) => {
+	const hook = useMutation<IRevokeInvitationData, IRevokeInvitationVariables>(REVOKE_INVITATION, opts)
+
+	return hook
+}

--- a/projects/frontend/src/graphql/queries/share-users-query.ts
+++ b/projects/frontend/src/graphql/queries/share-users-query.ts
@@ -1,0 +1,36 @@
+import { IUser, userKeys } from "../types";
+import gql from "graphql-tag";
+import { useQuery } from "react-apollo";
+
+export interface IShareUsersData {
+	share: {
+		id: string;
+		users: IUser[];
+	}
+}
+
+export interface IShareUsersVariables {
+	shareID: string;
+}
+
+const SHARE_USERS = gql`
+	query ShareUsers($shareID: String!) {
+		share(shareID: $shareID) {
+			id
+			users {
+				${userKeys}
+			}
+		}
+	}
+`
+
+export const useShareUsers = (shareID: string) => {
+	const { data, ...rest } = useQuery<IShareUsersData, IShareUsersVariables>(SHARE_USERS, {
+		variables: { shareID },
+	})
+
+	return {
+		data: data ? data.share.users : undefined,
+		...rest,
+	}
+}

--- a/projects/frontend/src/graphql/queries/shares-query.ts
+++ b/projects/frontend/src/graphql/queries/shares-query.ts
@@ -1,28 +1,26 @@
 import gql from "graphql-tag";
-import { IShare } from "../types";
+import { IShare, shareKeys } from "../types";
 import { useQuery } from "@apollo/react-hooks";
 
 export interface IGetSharesData {
 	viewer: {
+		id: string;
+		__typename: 'User';
 		shares: IShare[];
 	};
 }
 
-export interface IGetSharesVariables {
-	id: string;
-}
+export interface IGetSharesVariables { }
 
 export const GET_SHARES = gql`
   query user {
     viewer {
       id
       shares {
-        id
-        name
-        isLibrary
+        ${shareKeys}
       }
     }
   }
 `;
 
-export const useShares = () => useQuery<IGetSharesData, {}>(GET_SHARES);
+export const useShares = () => useQuery<IGetSharesData, IGetSharesVariables>(GET_SHARES);

--- a/projects/frontend/src/graphql/queries/user-query.ts
+++ b/projects/frontend/src/graphql/queries/user-query.ts
@@ -1,6 +1,6 @@
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/react-hooks";
-import { IShare } from "../types";
+import { IShare, shareKeys } from "../types";
 
 export interface IUserData {
 	viewer: {
@@ -14,9 +14,7 @@ export const GET_USER = gql`
     viewer {
       id
       shares {
-        id
-        name
-        isLibrary
+        ${shareKeys}
       }
     }
   }

--- a/projects/frontend/src/graphql/types.ts
+++ b/projects/frontend/src/graphql/types.ts
@@ -14,16 +14,28 @@ export interface IShare {
 	name: string;
 	userID: string;
 	isLibrary: boolean;
+	userPermissions: string[];
 }
 
-export interface IUserData {
+export interface IUser {
+	id: string;
+	name: string;
+	email: string;
+	status: 'accepted' | 'pending';
+}
+
+export interface IUserWithShares extends IUser {
 	user: {
 		shares: IShare[];
-		id: string;
-		name: string;
-		emails: string[];
 	};
 }
+
+export const userKeys = `
+	id
+	name
+	email
+	status
+`
 
 export interface IUserVariables {
 	id: string;
@@ -106,6 +118,7 @@ export const shareKeys = `
 	id
 	name
 	isLibrary
+	userPermissions
 `
 
 export interface IFile {

--- a/projects/frontend/src/graphql/types.ts
+++ b/projects/frontend/src/graphql/types.ts
@@ -10,6 +10,7 @@ export interface IShareData {
 
 export interface IShare {
 	id: string;
+	__typename: 'Share';
 	name: string;
 	userID: string;
 	isLibrary: boolean;
@@ -100,6 +101,12 @@ export const shareSongKeys = `
 export const playlistSongKeys = `
 	${baseSongKeys}
 `;
+
+export const shareKeys = `
+	id
+	name
+	isLibrary
+`
 
 export interface IFile {
 	readonly container: string;

--- a/projects/postgres-schema-builder/src/sql.ts
+++ b/projects/postgres-schema-builder/src/sql.ts
@@ -83,6 +83,15 @@ export namespace SQL {
 		return cql;
 	}
 
+	export const deleteEntry = (tableName: string, where: string[]) => {
+		const cql = `DELETE`
+			+ ` FROM ${tableName}`
+			+ ` WHERE ${where.map((column, i) => `("${column}" = $${i + 1})`).join(' AND ')}`
+			+ `;`;
+
+		return cql;
+	}
+
 	export const dropTable = (tableName: string) => `DROP TABLE ${tableName};`;
 
 	export const createIndex = (unique: boolean, name: string, column: string): string => {

--- a/projects/postgres-schema-builder/src/table.ts
+++ b/projects/postgres-schema-builder/src/table.ts
@@ -151,6 +151,7 @@ export interface ITable<C extends Columns> {
 	select<Subset extends Keys<C>, Where extends Keys<C>>(subset: Subset | "*", where: Where, allowFiltering?: boolean):
 		(conditions: ColumnValues<C, Where>) => IQuery<Pick<C, Extract<Subset[number], string>>>;
 	drop(): IQuery<{}>;
+	delete<Where extends Keys<C>>(where: Where): (conditions: ColumnValues<C, Where>) => IQuery<{}>;
 }
 
 export const Table =
@@ -202,5 +203,13 @@ export const Table =
 			drop: () => ({
 				sql: SQL.dropTable(table)
 			}),
+			delete: (where) => {
+				const sql = SQL.deleteEntry(table, where.filter(isString))
+
+				return (values) => ({
+					sql,
+					values,
+				})
+			}
 		}
 	}


### PR DESCRIPTION
Frontend:
* add `Create Share` button to shares dropdown header navigation
* add `Settings` submenu to every share in dropdown header navigation
* add share settings modal
  * rename share if owner
  * invite and revoke users via user table if owner
  * leave share button if member
  * delete share button if owner
* use global history object

Backend:
* add leave share mutation
* invalidate auth token on share creation/deletion
* remove postgres-schema-builder as external dependency and use locally linked one again

Closes #850 
Closes #201 