### PR TITLE
chore: frontend upgrade reactscripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We are working hard to release the first version of MusicShare. See the [roadmap
 1. Clone this repo
 2. Run `npm install` or `yarn install` to install and bootstrap dependencies
 3. Create local configurations for `frontend` and `backend` by copying the sample `.env` files (`cp projects/backend/config/development_sample.env projects/backend/development.env && cp projects/frontend/config/sample.env projects/frontend/.env`)
-4. Create and run `cassandra` database with docker (`docker-compose up`)
+4. Create and start `PostgreSQL` database with docker (`docker-compose up`)
 5. Run everything in `dev` mode by `npm run dev` or `yarn dev`
 
 If you want to run parts of the project seperatly, have a look at the provided scripts of the root [package.json](package.json).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ We are always happy welcoming new people contributing to this project. [Here's](
 ## Contributors
 * Yannick Stachelscheid ([@yss14](https://github.com/yss14))
 * Felix Wohnhaas ([@fewhnhouse](https://github.com/fewhnhouse))
+* Tobias Klesel ([@tobi12345](https://github.com/tobi12345))
+* Christian Diemers ([@Freshchris01](https://github.com/Freshchris01))
 
 ## License
 This project is licensed under the [AGPL](LICENSE) license.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ To execute the test cases, you need to create a separate `test.env`, for both th
 project (`cp projects/backend/config/development_sample.env projects/backend/test.env && cp projects/backend/config/development_sample.env projects/cassandra-schema-builder/test.env`), 
 and adjust the database connection variables accordingly.
 
+**Important notes**
+
+* Be sure to always run tsc in watch mode (e.g. via `dev:backend` npm script) when writing test cases since `ts-jest` is configured to skip type checking
+* When calling `executeGraphQLQuery` function in integration tests, the default *logged-in* user is `testData.users.user1`
+
 ## Contributing
 We are always happy welcoming new people contributing to this project. [Here's](https://github.com/yss14/musicshare/wiki/Contributing) a little guide to get started!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -304,34 +304,60 @@
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
-			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.0.tgz",
+			"integrity": "sha512-Cd8r8zs4RKDwMG/92lpZcnn5WPQ3LAMQbCw42oqUh4s7vsSN5ANUZjMel0OOnxDLq57hoDDbai+ryygYfCTOsw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-explode-assignable-expression": "^7.7.0",
+				"@babel/types": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
-			"integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.0.tgz",
+			"integrity": "sha512-LSln3cexwInTMYYoFeVLKnYPPMfWNJ8PubTBs3hkh7wCu9iBaqq1OOyW+xGmEdLxT1nhsl+9SJ+h2oUDYz0l2A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.3.0",
+				"@babel/types": "^7.7.0",
 				"esutils": "^2.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
-			"integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.0.tgz",
+			"integrity": "sha512-Su0Mdq7uSSWGZayGMMQ+z6lnL00mMCnGAbO/R0ZO9odIdB/WNU/VfQKqMQU0fdIsxQYbRjDM4BixIa93SQIpvw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.4.4",
-				"@babel/traverse": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/helper-hoist-variables": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -344,53 +370,84 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.6.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-					"integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.6.3",
+						"@babel/types": "^7.7.2",
 						"jsesc": "^2.5.1",
 						"lodash": "^4.17.13",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.6.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-					"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
 				"@babel/traverse": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-					"integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.6.3",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.6.3",
-						"@babel/types": "^7.6.3",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.13"
 					}
 				},
 				"@babel/types": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-					"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -416,32 +473,69 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.6.0.tgz",
-			"integrity": "sha512-O1QWBko4fzGju6VoVvrZg0RROCVifcLxiApnGP3OWfWzvxRZFCoBD81K5ur5e3bVY2Vf/5rIJm8cqPKn8HUJng==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.0.tgz",
+			"integrity": "sha512-MZiB5qvTWoyiFOgootmRSDV1udjIqJW/8lmxgzKq6oDqxdmHUjeP2ZUOmgHdYjmUVNABqRrHjYAYRvj8Eox/UA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-member-expression-to-functions": "^7.5.5",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/helper-member-expression-to-functions": "^7.7.0",
+				"@babel/helper-optimise-call-expression": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.5.5",
-				"@babel/helper-split-export-declaration": "^7.4.4"
+				"@babel/helper-replace-supers": "^7.7.0",
+				"@babel/helper-split-export-declaration": "^7.7.0"
 			},
 			"dependencies": {
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-					"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -451,21 +545,68 @@
 				}
 			}
 		},
-		"@babel/helper-define-map": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
-			"integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.2.tgz",
+			"integrity": "sha512-pAil/ZixjTlrzNpjx+l/C/wJk002Wo7XbbZ8oujH/AoJ3Juv0iN/UTcPUHXKMFLqsfS0Hy6Aow8M31brUYBlQQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/types": "^7.5.5",
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.6.0"
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.0.tgz",
+			"integrity": "sha512-kPKWPb0dMpZi+ov1hJiwse9dWweZsz3V9rP4KdytnX1E7z3cTNmFGglwklzFPuqIcHLIY3bgKSs4vkwXXdflQA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/types": "^7.7.0",
 				"lodash": "^4.17.13"
 			},
 			"dependencies": {
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
 				"@babel/types": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-					"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -476,13 +617,125 @@
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
-			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.0.tgz",
+			"integrity": "sha512-CDs26w2shdD1urNUAji2RJXyBFCaR+iBEGnFz3l7maizMkQe3saVw9WtjG1tz8CwbjvlFnaSLVhgnu1SWaherg==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.2",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-function-name": {
@@ -504,18 +757,18 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
-			"integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.0.tgz",
+			"integrity": "sha512-LUe/92NqsDAkJjjCEWkNe+/PcpnisvnqdlRe19FahVapa4jndeuJ+FBiTX1rcAKWKcJGE+C3Q3tuEuxkSmCEiQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.4"
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
 				"@babel/types": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-					"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -526,18 +779,18 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-			"integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.0.tgz",
+			"integrity": "sha512-QaCZLO2RtBcmvO/ekOLp8p7R5X2JriKRizeDpm5ChATAFWrrYDcDxPuCIBXKyBjY+i1vYSdcUTMIb8psfxHDPA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.5.5"
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
 				"@babel/types": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-					"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -556,49 +809,58 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
-			"integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.0.tgz",
+			"integrity": "sha512-rXEefBuheUYQyX4WjV19tuknrJFwyKw0HgzRwbkyTbB+Dshlq7eqkWbyjzToLrMZk/5wKVKdWFluiAsVkHXvuQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/helper-simple-access": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/template": "^7.4.4",
-				"@babel/types": "^7.5.5",
+				"@babel/helper-module-imports": "^7.7.0",
+				"@babel/helper-simple-access": "^7.7.0",
+				"@babel/helper-split-export-declaration": "^7.7.0",
+				"@babel/template": "^7.7.0",
+				"@babel/types": "^7.7.0",
 				"lodash": "^4.17.13"
 			},
 			"dependencies": {
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+				"@babel/helper-module-imports": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
+					"integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.6.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-					"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-					"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.6.0",
-						"@babel/types": "^7.6.0"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-					"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -609,12 +871,25 @@
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.0.tgz",
+			"integrity": "sha512-48TeqmbazjNU/65niiiJIJRc5JozB8acui1OS7bSd6PgxfuovWsvjfWSzlgx+gPFdVveNzUdpdIg5l56Pl5jqg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -633,28 +908,151 @@
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
-			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.0.tgz",
+			"integrity": "sha512-pHx7RN8X0UNHPB/fnuDnRXVZ316ZigkO8y8D835JlZ2SSdFKb6yH9MIYRU4fy/KPe5sPHDFOPvf8QLdbAGGiyw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-wrap-function": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-annotate-as-pure": "^7.7.0",
+				"@babel/helper-wrap-function": "^7.7.0",
+				"@babel/template": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.2",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.0.tgz",
+					"integrity": "sha512-k50CQxMlYTYo+GGyUGFwpxKVtxVJi9yh61sXZji3zYHccK9RYliZGSTOgci85T+r+0VFN2nWbGM04PIqwfrpMg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/code-frame": {
+							"version": "7.5.5",
+							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+							"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+							"dev": true,
+							"requires": {
+								"@babel/highlight": "^7.0.0"
+							}
+						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-			"integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.0.tgz",
+			"integrity": "sha512-5ALYEul5V8xNdxEeWvRsBzLMxQksT7MaStpxjJf9KsnLxpAKBtfw5NeMKZJSYDa0lKdOcy0g+JT/f5mPSulUgg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.5.5",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
+				"@babel/helper-member-expression-to-functions": "^7.7.0",
+				"@babel/helper-optimise-call-expression": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -667,53 +1065,84 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.6.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-					"integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.6.3",
+						"@babel/types": "^7.7.2",
 						"jsesc": "^2.5.1",
 						"lodash": "^4.17.13",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.6.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-					"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
 				"@babel/traverse": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-					"integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.6.3",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.6.3",
-						"@babel/types": "^7.6.3",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.13"
 					}
 				},
 				"@babel/types": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-					"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -739,13 +1168,43 @@
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
-			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.0.tgz",
+			"integrity": "sha512-AJ7IZD7Eem3zZRuj5JtzFAptBw7pMlS3y8Qv09vaBWoFsle0d1kAn5Wq6Q9MyBXITPOKnxwkZKoAm4bopmv26g==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/template": "^7.7.0",
+				"@babel/types": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/parser": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-split-export-declaration": {
@@ -757,15 +1216,129 @@
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
-			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.0.tgz",
+			"integrity": "sha512-sd4QjeMgQqzshSjecZjOp8uKfUtnpmCyQhKQrVJBBgeHAB/0FPi33h3AbVlVp07qQtMD4QgYSzaMI7VwncNK/w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.2.0"
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/template": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.2",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/code-frame": {
+							"version": "7.5.5",
+							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+							"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+							"dev": true,
+							"requires": {
+								"@babel/highlight": "^7.0.0"
+							}
+						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helpers": {
@@ -795,41 +1368,41 @@
 			"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
-			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.0.tgz",
+			"integrity": "sha512-ot/EZVvf3mXtZq0Pd0+tSOfGWMizqmOohXmNZg6LNFjHOV+wOPv7BvVYh8oPR8LhpIP3ye8nNooKL50YRWxpYA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.1.0",
+				"@babel/helper-remap-async-to-generator": "^7.7.0",
 				"@babel/plugin-syntax-async-generators": "^7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.3.0.tgz",
-			"integrity": "sha512-wNHxLkEKTQ2ay0tnsam2z7fGZUi+05ziDJflEt3AZTP3oXLKHJp9HqhfroB/vdMvt3sda9fAbq7FsG8QPDrZBg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
+			"integrity": "sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.3.0",
+				"@babel/helper-create-class-features-plugin": "^7.5.5",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-proposal-decorators": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.3.0.tgz",
-			"integrity": "sha512-3W/oCUmsO43FmZIqermmq6TKaRSYhmh/vybPfVFwQWdSb8xwki38uAIvknCRzuyHRuYfCYmJzL9or1v0AffPjg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.6.0.tgz",
+			"integrity": "sha512-ZSyYw9trQI50sES6YxREXKu+4b7MAg6Qx2cvyDDYjP2Hpzd3FleOUwC9cqn1+za8d0A2ZU8SHujxFao956efUg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.3.0",
+				"@babel/helper-create-class-features-plugin": "^7.6.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-decorators": "^7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
-			"integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.0.tgz",
+			"integrity": "sha512-7poL3Xi+QFPC7sGAzEIbXUyYzGJwbc2+gSD0AkiC5k52kH2cqHdqxm5hNFfLW3cRSTcx9bN0Fl7/6zWcLLnKAQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -867,14 +1440,13 @@
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
-			"integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.0.tgz",
+			"integrity": "sha512-mk34H+hp7kRBWJOOAR0ZMGCydgKMD4iN9TpDRp3IIcbunltxEY89XSimc6WbtSLCDrwcdy/EEw7h5CFCzxTchw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.6.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -905,9 +1477,9 @@
 			}
 		},
 		"@babel/plugin-syntax-flow": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
-			"integrity": "sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.7.0.tgz",
+			"integrity": "sha512-vQMV07p+L+jZeUnvX3pEJ9EiXGCjB5CTTvsirFD9rpEuATnoAvLBLoYbw1v5tyn3d2XxSuvEKi8cV3KqYUa0vQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -949,6 +1521,15 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.0.tgz",
+			"integrity": "sha512-hi8FUNiFIY1fnUI2n1ViB1DR0R4QeK4iHcTlW6aJkrPoTdb8Rf1EMQ6GT3f67DDkYyWgew9DFoOZ6gOoEsdzTA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-syntax-typescript": {
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
@@ -968,14 +1549,36 @@
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
-			"integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.0.tgz",
+			"integrity": "sha512-vLI2EFLVvRBL3d8roAMqtVY0Bm9C1QzLkdS57hiKrjUBSqsQYrBsMCeOg/0KK7B0eK9V71J5mWcha9yyoI2tZw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-module-imports": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.1.0"
+				"@babel/helper-remap-async-to-generator": "^7.7.0"
+			},
+			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
+					"integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
@@ -998,34 +1601,80 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
-			"integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.0.tgz",
+			"integrity": "sha512-/b3cKIZwGeUesZheU9jNYcwrEA7f/Bo4IdPmvp7oHgvks2majB5BoT5byAql44fiNQYOPzhk2w8DbgfuafkMoA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-define-map": "^7.5.5",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-annotate-as-pure": "^7.7.0",
+				"@babel/helper-define-map": "^7.7.0",
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/helper-optimise-call-expression": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.5.5",
-				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/helper-replace-supers": "^7.7.0",
+				"@babel/helper-split-export-declaration": "^7.7.0",
 				"globals": "^11.1.0"
 			},
 			"dependencies": {
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.0.tgz",
+					"integrity": "sha512-k50CQxMlYTYo+GGyUGFwpxKVtxVJi9yh61sXZji3zYHccK9RYliZGSTOgci85T+r+0VFN2nWbGM04PIqwfrpMg==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-					"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -1054,14 +1703,13 @@
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
-			"integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.0.tgz",
+			"integrity": "sha512-3QQlF7hSBnSuM1hQ0pS3pmAbWLax/uGNCbPBND9y+oJ4Y776jsyujG2k0Sn2Aj2a0QwVOiOFL5QVPA7spjvzSA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.6.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
@@ -1084,9 +1732,9 @@
 			}
 		},
 		"@babel/plugin-transform-flow-strip-types": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.2.3.tgz",
-			"integrity": "sha512-xnt7UIk9GYZRitqCnsVMjQK1O2eKZwFB3CvvHjf5SGx6K6vr/MScCKQDnf1DxRaj501e3pXjti+inbSXX2ZUoQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.4.tgz",
+			"integrity": "sha512-WyVedfeEIILYEaWGAUWzVNyqG4sfsNooMhXWsu/YzOvVGcsnPb5PguysjJqI3t3qiaYj0BR8T2f5njdjTGe44Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -1103,13 +1751,63 @@
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
-			"integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.0.tgz",
+			"integrity": "sha512-P5HKu0d9+CzZxP5jcrWdpe7ZlFDe24bmqP6a6X8BHEBl/eizAsY8K6LX8LASZL0Jxdjm5eEfzp+FIrxCm/p8bA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-function-name": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-literals": {
@@ -1142,45 +1840,45 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
-			"integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.0.tgz",
+			"integrity": "sha512-KEMyWNNWnjOom8vR/1+d+Ocz/mILZG/eyHHO06OuBQ2aNhxT62fr4y6fGOplRx+CxCSp3IFwesL8WdINfY/3kg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.4.4",
+				"@babel/helper-module-transforms": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-simple-access": "^7.1.0",
+				"@babel/helper-simple-access": "^7.7.0",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
-			"integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.0.tgz",
+			"integrity": "sha512-ZAuFgYjJzDNv77AjXRqzQGlQl4HdUM6j296ee4fwKVZfhDR9LAGxfvXjBkb06gNETPnN0sLqRm9Gxg4wZH6dXg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.4.4",
+				"@babel/helper-hoist-variables": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
-			"integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.0.tgz",
+			"integrity": "sha512-u7eBA03zmUswQ9LQ7Qw0/ieC1pcAkbp5OQatbWUzY1PaBccvuJXUkYzoN1g7cqp7dbTu6Dp9bXyalBvD04AANA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-module-transforms": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
-			"integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.0.tgz",
+			"integrity": "sha512-+SicSJoKouPctL+j1pqktRVCgy+xAch1hWWTMy13j0IflnyNjaoskj+DwRQFimHbLqO3sq2oN2CXMvXq3Bgapg==",
 			"dev": true,
 			"requires": {
-				"regexpu-core": "^4.6.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -1242,12 +1940,12 @@
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
-			"integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.0.tgz",
+			"integrity": "sha512-mXhBtyVB1Ujfy+0L6934jeJcSXj/VCg6whZzEcgiiZHNS0PGC7vUCsZDQCxxztkpIdF+dY1fUMcjAgEOC3ZOMQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx": "^7.3.0",
+				"@babel/helper-builder-react-jsx": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-jsx": "^7.2.0"
 			}
@@ -1273,9 +1971,9 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
-			"integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.0.tgz",
+			"integrity": "sha512-AXmvnC+0wuj/cFkkS/HFHIojxH3ffSXE+ttulrqWjZZRaUOonfJc60e1wSNT4rV8tIunvu/R3wCp71/tLAa9xg==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.14.0"
@@ -1291,9 +1989,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
-			"integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz",
+			"integrity": "sha512-Da8tMf7uClzwUm/pnJ1S93m/aRXmoYNDD7TkHua8xBDdaAs54uZpTWvEt6NGwmoVMb9mZbntfTqmG2oSzN/7Vg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -1350,78 +2048,78 @@
 			}
 		},
 		"@babel/plugin-transform-typescript": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.6.3.tgz",
-			"integrity": "sha512-aiWINBrPMSC3xTXRNM/dfmyYuPNKY/aexYqBgh0HBI5Y+WO5oRAqW/oROYeYHrF4Zw12r9rK4fMk/ZlAmqx/FQ==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.7.2.tgz",
+			"integrity": "sha512-UWhDaJRqdPUtdK1s0sKYdoRuqK0NepjZto2UZltvuCgMoMZmdjhgz5hcRokie/3aYEaSz3xvusyoayVaq4PjRg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.6.0",
+				"@babel/helper-create-class-features-plugin": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-typescript": "^7.2.0"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
-			"integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.0.tgz",
+			"integrity": "sha512-RrThb0gdrNwFAqEAAx9OWgtx6ICK69x7i9tCnMdVrxQwSDp/Abu9DXFU5Hh16VP33Rmxh04+NGW28NsIkFvFKA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.6.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
-			"integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.1.tgz",
+			"integrity": "sha512-/93SWhi3PxcVTDpSqC+Dp4YxUu3qZ4m7I76k0w73wYfn7bGVuRIO4QUz95aJksbS+AD1/mT1Ie7rbkT0wSplaA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-module-imports": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-				"@babel/plugin-proposal-dynamic-import": "^7.5.0",
+				"@babel/plugin-proposal-async-generator-functions": "^7.7.0",
+				"@babel/plugin-proposal-dynamic-import": "^7.7.0",
 				"@babel/plugin-proposal-json-strings": "^7.2.0",
 				"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.7.0",
 				"@babel/plugin-syntax-async-generators": "^7.2.0",
 				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
 				"@babel/plugin-syntax-json-strings": "^7.2.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+				"@babel/plugin-syntax-top-level-await": "^7.7.0",
 				"@babel/plugin-transform-arrow-functions": "^7.2.0",
-				"@babel/plugin-transform-async-to-generator": "^7.5.0",
+				"@babel/plugin-transform-async-to-generator": "^7.7.0",
 				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
 				"@babel/plugin-transform-block-scoping": "^7.6.3",
-				"@babel/plugin-transform-classes": "^7.5.5",
+				"@babel/plugin-transform-classes": "^7.7.0",
 				"@babel/plugin-transform-computed-properties": "^7.2.0",
 				"@babel/plugin-transform-destructuring": "^7.6.0",
-				"@babel/plugin-transform-dotall-regex": "^7.6.2",
+				"@babel/plugin-transform-dotall-regex": "^7.7.0",
 				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
 				"@babel/plugin-transform-for-of": "^7.4.4",
-				"@babel/plugin-transform-function-name": "^7.4.4",
+				"@babel/plugin-transform-function-name": "^7.7.0",
 				"@babel/plugin-transform-literals": "^7.2.0",
 				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
 				"@babel/plugin-transform-modules-amd": "^7.5.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.6.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.5.0",
-				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
+				"@babel/plugin-transform-modules-commonjs": "^7.7.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.7.0",
+				"@babel/plugin-transform-modules-umd": "^7.7.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.0",
 				"@babel/plugin-transform-new-target": "^7.4.4",
 				"@babel/plugin-transform-object-super": "^7.5.5",
 				"@babel/plugin-transform-parameters": "^7.4.4",
 				"@babel/plugin-transform-property-literals": "^7.2.0",
-				"@babel/plugin-transform-regenerator": "^7.4.5",
+				"@babel/plugin-transform-regenerator": "^7.7.0",
 				"@babel/plugin-transform-reserved-words": "^7.2.0",
 				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
 				"@babel/plugin-transform-spread": "^7.6.2",
 				"@babel/plugin-transform-sticky-regex": "^7.2.0",
 				"@babel/plugin-transform-template-literals": "^7.4.4",
 				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.6.2",
-				"@babel/types": "^7.6.3",
+				"@babel/plugin-transform-unicode-regex": "^7.7.0",
+				"@babel/types": "^7.7.1",
 				"browserslist": "^4.6.0",
 				"core-js-compat": "^3.1.1",
 				"invariant": "^2.2.2",
@@ -1429,10 +2127,19 @@
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
+					"integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
 				"@babel/types": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-					"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -1443,26 +2150,26 @@
 			}
 		},
 		"@babel/preset-react": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.6.3.tgz",
-			"integrity": "sha512-07yQhmkZmRAfwREYIQgW0HEwMY9GBJVuPY4Q12UC72AbfaawuupVWa8zQs2tlL+yun45Nv/1KreII/0PLfEsgA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.7.0.tgz",
+			"integrity": "sha512-IXXgSUYBPHUGhUkH+89TR6faMcBtuMW0h5OHbMuVbL3/5wK2g6a2M2BBpkLa+Kw0sAHiZ9dNVgqJMDP/O4GRBA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-transform-react-display-name": "^7.0.0",
-				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.7.0",
 				"@babel/plugin-transform-react-jsx-self": "^7.0.0",
 				"@babel/plugin-transform-react-jsx-source": "^7.0.0"
 			}
 		},
 		"@babel/preset-typescript": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.1.0.tgz",
-			"integrity": "sha512-LYveByuF9AOM8WrsNne5+N79k1YxjNB6gmpCQsnuSBAcV8QUeB+ZUxQzL7Rz7HksPbahymKkq2qBR+o36ggFZA==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.6.0.tgz",
+			"integrity": "sha512-4xKw3tTcCm0qApyT6PqM9qniseCE79xGHiUnNdKGdxNsGUc2X7WwZybqIpnTmoukg3nhPceI5KPNzNqLNeIJww==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-transform-typescript": "^7.1.0"
+				"@babel/plugin-transform-typescript": "^7.6.0"
 			}
 		},
 		"@babel/runtime": {
@@ -1545,6 +2252,12 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
 			"integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==",
+			"dev": true
+		},
+		"@csstools/normalize.css": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-9.0.1.tgz",
+			"integrity": "sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==",
 			"dev": true
 		},
 		"@emotion/is-prop-valid": {
@@ -1738,6 +2451,45 @@
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
+			}
+		},
+		"@hapi/address": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+			"integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==",
+			"dev": true
+		},
+		"@hapi/bourne": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+			"integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+			"dev": true
+		},
+		"@hapi/hoek": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+			"integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==",
+			"dev": true
+		},
+		"@hapi/joi": {
+			"version": "15.1.1",
+			"resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+			"integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/address": "2.x.x",
+				"@hapi/bourne": "1.x.x",
+				"@hapi/hoek": "8.x.x",
+				"@hapi/topo": "3.x.x"
+			}
+		},
+		"@hapi/topo": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+			"integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "^8.3.0"
 			}
 		},
 		"@jest/console": {
@@ -4332,9 +5084,9 @@
 			},
 			"dependencies": {
 				"@babel/types": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-					"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -4366,19 +5118,19 @@
 					}
 				},
 				"@babel/core": {
-					"version": "7.6.4",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
-					"integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.2.tgz",
+					"integrity": "sha512-eeD7VEZKfhK1KUXGiyPFettgF3m513f8FoBSWiQ1xTvl1RAopLs42Wp9+Ze911I6H0N9lNqJMDgoZT7gHsipeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.6.4",
-						"@babel/helpers": "^7.6.2",
-						"@babel/parser": "^7.6.4",
-						"@babel/template": "^7.6.0",
-						"@babel/traverse": "^7.6.3",
-						"@babel/types": "^7.6.3",
-						"convert-source-map": "^1.1.0",
+						"@babel/generator": "^7.7.2",
+						"@babel/helpers": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/template": "^7.7.0",
+						"@babel/traverse": "^7.7.2",
+						"@babel/types": "^7.7.2",
+						"convert-source-map": "^1.7.0",
 						"debug": "^4.1.0",
 						"json5": "^2.1.0",
 						"lodash": "^4.17.13",
@@ -4388,80 +5140,109 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.6.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-					"integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.6.3",
+						"@babel/types": "^7.7.2",
 						"jsesc": "^2.5.1",
 						"lodash": "^4.17.13",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.4.4"
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/helpers": {
-					"version": "7.6.2",
-					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
-					"integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
+					"integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
 					"dev": true,
 					"requires": {
-						"@babel/template": "^7.6.0",
-						"@babel/traverse": "^7.6.2",
-						"@babel/types": "^7.6.0"
+						"@babel/template": "^7.7.0",
+						"@babel/traverse": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.6.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-					"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
 				"@babel/template": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-					"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.6.0",
-						"@babel/types": "^7.6.0"
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-					"integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.6.3",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.6.3",
-						"@babel/types": "^7.6.3",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.13"
 					}
 				},
 				"@babel/types": {
-					"version": "7.6.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-					"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"convert-source-map": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+					"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.1"
 					}
 				},
 				"debug": {
@@ -4517,19 +5298,173 @@
 			}
 		},
 		"@svgr/webpack": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-4.1.0.tgz",
-			"integrity": "sha512-d09ehQWqLMywP/PT/5JvXwPskPK9QCXUjiSkAHehreB381qExXf5JFCBWhfEyNonRbkIneCeYM99w+Ud48YIQQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-4.3.2.tgz",
+			"integrity": "sha512-F3VE5OvyOWBEd2bF7BdtFRyI6E9it3mN7teDw0JQTlVtc4HZEYiiLSl+Uf9Uub6IYHVGc+qIrxxDyeedkQru2w==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.1.6",
+				"@babel/core": "^7.4.5",
 				"@babel/plugin-transform-react-constant-elements": "^7.0.0",
-				"@babel/preset-env": "^7.1.6",
+				"@babel/preset-env": "^7.4.5",
 				"@babel/preset-react": "^7.0.0",
-				"@svgr/core": "^4.1.0",
-				"@svgr/plugin-jsx": "^4.1.0",
-				"@svgr/plugin-svgo": "^4.0.3",
-				"loader-utils": "^1.1.0"
+				"@svgr/core": "^4.3.2",
+				"@svgr/plugin-jsx": "^4.3.2",
+				"@svgr/plugin-svgo": "^4.3.1",
+				"loader-utils": "^1.2.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/core": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.2.tgz",
+					"integrity": "sha512-eeD7VEZKfhK1KUXGiyPFettgF3m513f8FoBSWiQ1xTvl1RAopLs42Wp9+Ze911I6H0N9lNqJMDgoZT7gHsipeQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helpers": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/template": "^7.7.0",
+						"@babel/traverse": "^7.7.2",
+						"@babel/types": "^7.7.2",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"json5": "^2.1.0",
+						"lodash": "^4.17.13",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.2",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
+					"integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.7.0",
+						"@babel/traverse": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"convert-source-map": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+					"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.1"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@types/accepts": {
@@ -5053,12 +5988,6 @@
 				"@types/superagent": "*"
 			}
 		},
-		"@types/tapable": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.2.tgz",
-			"integrity": "sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ==",
-			"dev": true
-		},
 		"@types/tunnel": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.0.tgz",
@@ -5338,175 +6267,179 @@
 			}
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
-			"integrity": "sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+			"integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/helper-module-context": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/wast-parser": "1.7.11"
+				"@webassemblyjs/helper-module-context": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/wast-parser": "1.8.5"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz",
-			"integrity": "sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+			"integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz",
-			"integrity": "sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+			"integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz",
-			"integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+			"integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-code-frame": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz",
-			"integrity": "sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+			"integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/wast-printer": "1.7.11"
+				"@webassemblyjs/wast-printer": "1.8.5"
 			}
 		},
 		"@webassemblyjs/helper-fsm": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz",
-			"integrity": "sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+			"integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-module-context": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz",
-			"integrity": "sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==",
-			"dev": true
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+			"integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+			"dev": true,
+			"requires": {
+				"@webassemblyjs/ast": "1.8.5",
+				"mamacro": "^0.0.3"
+			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz",
-			"integrity": "sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+			"integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz",
-			"integrity": "sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+			"integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-buffer": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/wasm-gen": "1.7.11"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz",
-			"integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+			"integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
 			"dev": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.11.tgz",
-			"integrity": "sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+			"integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
 			"dev": true,
 			"requires": {
-				"@xtuc/long": "4.2.1"
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.11.tgz",
-			"integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+			"integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
 			"dev": true
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz",
-			"integrity": "sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+			"integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-buffer": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/helper-wasm-section": "1.7.11",
-				"@webassemblyjs/wasm-gen": "1.7.11",
-				"@webassemblyjs/wasm-opt": "1.7.11",
-				"@webassemblyjs/wasm-parser": "1.7.11",
-				"@webassemblyjs/wast-printer": "1.7.11"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/helper-wasm-section": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5",
+				"@webassemblyjs/wasm-opt": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5",
+				"@webassemblyjs/wast-printer": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz",
-			"integrity": "sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+			"integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/ieee754": "1.7.11",
-				"@webassemblyjs/leb128": "1.7.11",
-				"@webassemblyjs/utf8": "1.7.11"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/ieee754": "1.8.5",
+				"@webassemblyjs/leb128": "1.8.5",
+				"@webassemblyjs/utf8": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz",
-			"integrity": "sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+			"integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-buffer": "1.7.11",
-				"@webassemblyjs/wasm-gen": "1.7.11",
-				"@webassemblyjs/wasm-parser": "1.7.11"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz",
-			"integrity": "sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+			"integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-api-error": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/ieee754": "1.7.11",
-				"@webassemblyjs/leb128": "1.7.11",
-				"@webassemblyjs/utf8": "1.7.11"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-api-error": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/ieee754": "1.8.5",
+				"@webassemblyjs/leb128": "1.8.5",
+				"@webassemblyjs/utf8": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wast-parser": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz",
-			"integrity": "sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+			"integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/floating-point-hex-parser": "1.7.11",
-				"@webassemblyjs/helper-api-error": "1.7.11",
-				"@webassemblyjs/helper-code-frame": "1.7.11",
-				"@webassemblyjs/helper-fsm": "1.7.11",
-				"@xtuc/long": "4.2.1"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/floating-point-hex-parser": "1.8.5",
+				"@webassemblyjs/helper-api-error": "1.8.5",
+				"@webassemblyjs/helper-code-frame": "1.8.5",
+				"@webassemblyjs/helper-fsm": "1.8.5",
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz",
-			"integrity": "sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+			"integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/wast-parser": "1.7.11",
-				"@xtuc/long": "4.2.1"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/wast-parser": "1.8.5",
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@wry/context": {
@@ -5533,9 +6466,9 @@
 			"dev": true
 		},
 		"@xtuc/long": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
-			"integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
 		"@zkochan/cmd-shim": {
@@ -5600,15 +6533,6 @@
 			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
 			"dev": true
 		},
-		"acorn-dynamic-import": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-			"dev": true,
-			"requires": {
-				"acorn": "^5.0.0"
-			}
-		},
 		"acorn-globals": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
@@ -5648,10 +6572,31 @@
 			}
 		},
 		"address": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
-			"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/address/-/address-1.1.2.tgz",
+			"integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==",
 			"dev": true
+		},
+		"adjust-sourcemap-loader": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-2.0.0.tgz",
+			"integrity": "sha512-4hFsTsn58+YjrU9qKzML2JSSDqKvN8mUGQ0nNIrfPi8hmIONT4L3uUaT6MKdMsZ9AjsU6D2xDkZxCkbQPxChrA==",
+			"dev": true,
+			"requires": {
+				"assert": "1.4.1",
+				"camelcase": "5.0.0",
+				"loader-utils": "1.2.3",
+				"object-path": "0.11.4",
+				"regex-parser": "2.2.10"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+					"dev": true
+				}
+			}
 		},
 		"adm-zip": {
 			"version": "0.4.13",
@@ -6423,15 +7368,6 @@
 				"tslib": "^1.9.3"
 			}
 		},
-		"append-transform": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-			"dev": true,
-			"requires": {
-				"default-require-extensions": "^1.0.0"
-			}
-		},
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -6506,6 +7442,12 @@
 				"commander": "^2.11.0"
 			}
 		},
+		"arity-n": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz",
+			"integrity": "sha1-2edrEXM+CFacCEeuezmyhgswt0U=",
+			"dev": true
+		},
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -6536,12 +7478,6 @@
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
 		},
-		"array-filter": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-			"dev": true
-		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -6568,18 +7504,6 @@
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.7.0"
 			}
-		},
-		"array-map": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-			"dev": true
-		},
-		"array-reduce": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-			"dev": true
 		},
 		"array-tree-filter": {
 			"version": "2.1.0",
@@ -6638,30 +7562,12 @@
 			}
 		},
 		"assert": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
-			"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
 			"dev": true,
 			"requires": {
-				"object-assign": "^4.1.1",
 				"util": "0.10.3"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-					"dev": true
-				},
-				"util": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-					"dev": true,
-					"requires": {
-						"inherits": "2.0.1"
-					}
-				}
 			}
 		},
 		"assert-plus": {
@@ -6759,51 +7665,25 @@
 			}
 		},
 		"autoprefixer": {
-			"version": "9.7.0",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.0.tgz",
-			"integrity": "sha512-j2IRvaCfrUxIiZun9ba4mhJ2omhw4OY88/yVzLO+lHhGBumAAK72PgM6gkbSN8iregPOn1ZlxGkmZh2CQ7X4AQ==",
+			"version": "9.7.1",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.1.tgz",
+			"integrity": "sha512-w3b5y1PXWlhYulevrTJ0lizkQ5CyqfeU6BIRDbuhsMupstHQOeb1Ur80tcB1zxSu7AwyY/qCQ7Vvqklh31ZBFw==",
 			"dev": true,
 			"requires": {
 				"browserslist": "^4.7.2",
-				"caniuse-lite": "^1.0.30001004",
+				"caniuse-lite": "^1.0.30001006",
 				"chalk": "^2.4.2",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.19",
+				"postcss": "^7.0.21",
 				"postcss-value-parser": "^4.0.2"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"postcss-value-parser": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
 					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
 					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -7037,17 +7917,28 @@
 			}
 		},
 		"babel-eslint": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
-			"integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+			"integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.0.0",
 				"@babel/traverse": "^7.0.0",
 				"@babel/types": "^7.0.0",
-				"eslint-scope": "3.7.1",
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.0.0",
+				"resolve": "^1.12.0"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.12.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+					"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				}
 			}
 		},
 		"babel-extract-comments": {
@@ -7126,15 +8017,23 @@
 			}
 		},
 		"babel-loader": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.5.tgz",
-			"integrity": "sha512-NTnHnVRd2JnRqPC0vW+iOQWU5pchDbYXsG2E6DMXEpMfUcQKclF9gmf3G3ZMhzG7IG9ji4coL0cm+FxeWxDpnw==",
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
+			"integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
 			"dev": true,
 			"requires": {
 				"find-cache-dir": "^2.0.0",
 				"loader-utils": "^1.0.2",
 				"mkdirp": "^0.5.1",
-				"util.promisify": "^1.0.0"
+				"pify": "^4.0.1"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				}
 			}
 		},
 		"babel-messages": {
@@ -7231,13 +8130,14 @@
 			}
 		},
 		"babel-plugin-macros": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.0.tgz",
-			"integrity": "sha512-BWw0lD0kVZAXRD3Od1kMrdmfudqzDzYv2qrN3l2ISR1HVp1EgLKfbOrYV9xmY5k3qx3RIu5uPAUZZZHpo0o5Iw==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz",
+			"integrity": "sha512-6W2nwiXme6j1n2erPOnmRiWfObUhWH7Qw1LMi9XZy8cj+KtESu3T6asZvtk5bMQQjX8te35o7CFueiSdL/2NmQ==",
 			"dev": true,
 			"requires": {
-				"cosmiconfig": "^5.0.5",
-				"resolve": "^1.8.1"
+				"@babel/runtime": "^7.4.2",
+				"cosmiconfig": "^5.2.0",
+				"resolve": "^1.10.0"
 			}
 		},
 		"babel-plugin-named-asset-import": {
@@ -7314,148 +8214,184 @@
 			}
 		},
 		"babel-preset-react-app": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-7.0.2.tgz",
-			"integrity": "sha512-mwCk/u2wuiO8qQqblN5PlDa44taY0acq7hw6W+a70W522P7a9mIcdggL1fe5/LgAT7tqCq46q9wwhqaMoYKslQ==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-9.0.2.tgz",
+			"integrity": "sha512-aXD+CTH8Chn8sNJr4tO/trWKqe5sSE4hdO76j9fhVezJSzmpWYWUSc5JoPmdSxADwef5kQFNGKXd433vvkd2VQ==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "7.2.2",
-				"@babel/plugin-proposal-class-properties": "7.3.0",
-				"@babel/plugin-proposal-decorators": "7.3.0",
-				"@babel/plugin-proposal-object-rest-spread": "7.3.2",
+				"@babel/core": "7.6.0",
+				"@babel/plugin-proposal-class-properties": "7.5.5",
+				"@babel/plugin-proposal-decorators": "7.6.0",
+				"@babel/plugin-proposal-object-rest-spread": "7.5.5",
 				"@babel/plugin-syntax-dynamic-import": "7.2.0",
-				"@babel/plugin-transform-classes": "7.2.2",
-				"@babel/plugin-transform-destructuring": "7.3.2",
-				"@babel/plugin-transform-flow-strip-types": "7.2.3",
-				"@babel/plugin-transform-react-constant-elements": "7.2.0",
+				"@babel/plugin-transform-destructuring": "7.6.0",
+				"@babel/plugin-transform-flow-strip-types": "7.4.4",
 				"@babel/plugin-transform-react-display-name": "7.2.0",
-				"@babel/plugin-transform-runtime": "7.2.0",
-				"@babel/preset-env": "7.3.1",
+				"@babel/plugin-transform-runtime": "7.6.0",
+				"@babel/preset-env": "7.6.0",
 				"@babel/preset-react": "7.0.0",
-				"@babel/preset-typescript": "7.1.0",
-				"@babel/runtime": "7.3.1",
-				"babel-loader": "8.0.5",
-				"babel-plugin-dynamic-import-node": "2.2.0",
-				"babel-plugin-macros": "2.5.0",
+				"@babel/preset-typescript": "7.6.0",
+				"@babel/runtime": "7.6.0",
+				"babel-plugin-dynamic-import-node": "2.3.0",
+				"babel-plugin-macros": "2.6.1",
 				"babel-plugin-transform-react-remove-prop-types": "0.4.24"
 			},
 			"dependencies": {
-				"@babel/core": {
-					"version": "7.2.2",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
-					"integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.2.2",
-						"@babel/helpers": "^7.2.0",
-						"@babel/parser": "^7.2.2",
-						"@babel/template": "^7.2.2",
-						"@babel/traverse": "^7.2.2",
-						"@babel/types": "^7.2.2",
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/core": {
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
+					"integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.6.0",
+						"@babel/helpers": "^7.6.0",
+						"@babel/parser": "^7.6.0",
+						"@babel/template": "^7.6.0",
+						"@babel/traverse": "^7.6.0",
+						"@babel/types": "^7.6.0",
 						"convert-source-map": "^1.1.0",
 						"debug": "^4.1.0",
 						"json5": "^2.1.0",
-						"lodash": "^4.17.10",
+						"lodash": "^4.17.13",
 						"resolve": "^1.3.2",
 						"semver": "^5.4.1",
 						"source-map": "^0.5.0"
 					}
 				},
+				"@babel/generator": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.2",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
+					"integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.7.0",
+						"@babel/traverse": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
+					"dev": true
+				},
 				"@babel/plugin-proposal-object-rest-spread": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz",
-					"integrity": "sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
+					"integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-plugin-utils": "^7.0.0",
 						"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
 					}
 				},
-				"@babel/plugin-transform-classes": {
-					"version": "7.2.2",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.2.2.tgz",
-					"integrity": "sha512-gEZvgTy1VtcDOaQty1l10T3jQmJKlNVxLDCs+3rCVPr6nMkODLELxViq5X9l+rfxbie3XrfrMCYYY6eX3aOcOQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.0.0",
-						"@babel/helper-define-map": "^7.1.0",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-optimise-call-expression": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-replace-supers": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.0.0",
-						"globals": "^11.1.0"
-					}
-				},
-				"@babel/plugin-transform-destructuring": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz",
-					"integrity": "sha512-Lrj/u53Ufqxl/sGxyjsJ2XNtNuEjDyjpqdhMNh5aZ+XFOdThL46KBj27Uem4ggoezSYBxKWAil6Hu8HtwqesYw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-react-constant-elements": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.2.0.tgz",
-					"integrity": "sha512-YYQFg6giRFMsZPKUM9v+VcHOdfSQdz9jHCx3akAi3UYgyjndmdYGSXylQ/V+HswQt4fL8IklchD9HTsaOCrWQQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
 				"@babel/preset-env": {
-					"version": "7.3.1",
-					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.1.tgz",
-					"integrity": "sha512-FHKrD6Dxf30e8xgHQO0zJZpUPfVZg+Xwgz5/RdSWCbza9QLNk4Qbp40ctRoqDxml3O8RMzB1DU55SXeDG6PqHQ==",
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.0.tgz",
+					"integrity": "sha512-1efzxFv/TcPsNXlRhMzRnkBFMeIqBBgzwmZwlFDw5Ubj0AGLeufxugirwZmkkX/ayi3owsSqoQ4fw8LkfK9SYg==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-imports": "^7.0.0",
 						"@babel/helper-plugin-utils": "^7.0.0",
 						"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+						"@babel/plugin-proposal-dynamic-import": "^7.5.0",
 						"@babel/plugin-proposal-json-strings": "^7.2.0",
-						"@babel/plugin-proposal-object-rest-spread": "^7.3.1",
+						"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
 						"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-						"@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
 						"@babel/plugin-syntax-async-generators": "^7.2.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.2.0",
 						"@babel/plugin-syntax-json-strings": "^7.2.0",
 						"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
 						"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
 						"@babel/plugin-transform-arrow-functions": "^7.2.0",
-						"@babel/plugin-transform-async-to-generator": "^7.2.0",
+						"@babel/plugin-transform-async-to-generator": "^7.5.0",
 						"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-						"@babel/plugin-transform-block-scoping": "^7.2.0",
-						"@babel/plugin-transform-classes": "^7.2.0",
+						"@babel/plugin-transform-block-scoping": "^7.6.0",
+						"@babel/plugin-transform-classes": "^7.5.5",
 						"@babel/plugin-transform-computed-properties": "^7.2.0",
-						"@babel/plugin-transform-destructuring": "^7.2.0",
-						"@babel/plugin-transform-dotall-regex": "^7.2.0",
-						"@babel/plugin-transform-duplicate-keys": "^7.2.0",
+						"@babel/plugin-transform-destructuring": "^7.6.0",
+						"@babel/plugin-transform-dotall-regex": "^7.4.4",
+						"@babel/plugin-transform-duplicate-keys": "^7.5.0",
 						"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-						"@babel/plugin-transform-for-of": "^7.2.0",
-						"@babel/plugin-transform-function-name": "^7.2.0",
+						"@babel/plugin-transform-for-of": "^7.4.4",
+						"@babel/plugin-transform-function-name": "^7.4.4",
 						"@babel/plugin-transform-literals": "^7.2.0",
-						"@babel/plugin-transform-modules-amd": "^7.2.0",
-						"@babel/plugin-transform-modules-commonjs": "^7.2.0",
-						"@babel/plugin-transform-modules-systemjs": "^7.2.0",
+						"@babel/plugin-transform-member-expression-literals": "^7.2.0",
+						"@babel/plugin-transform-modules-amd": "^7.5.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.6.0",
+						"@babel/plugin-transform-modules-systemjs": "^7.5.0",
 						"@babel/plugin-transform-modules-umd": "^7.2.0",
-						"@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
-						"@babel/plugin-transform-new-target": "^7.0.0",
-						"@babel/plugin-transform-object-super": "^7.2.0",
-						"@babel/plugin-transform-parameters": "^7.2.0",
-						"@babel/plugin-transform-regenerator": "^7.0.0",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.6.0",
+						"@babel/plugin-transform-new-target": "^7.4.4",
+						"@babel/plugin-transform-object-super": "^7.5.5",
+						"@babel/plugin-transform-parameters": "^7.4.4",
+						"@babel/plugin-transform-property-literals": "^7.2.0",
+						"@babel/plugin-transform-regenerator": "^7.4.5",
+						"@babel/plugin-transform-reserved-words": "^7.2.0",
 						"@babel/plugin-transform-shorthand-properties": "^7.2.0",
 						"@babel/plugin-transform-spread": "^7.2.0",
 						"@babel/plugin-transform-sticky-regex": "^7.2.0",
-						"@babel/plugin-transform-template-literals": "^7.2.0",
+						"@babel/plugin-transform-template-literals": "^7.4.4",
 						"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-						"@babel/plugin-transform-unicode-regex": "^7.2.0",
-						"browserslist": "^4.3.4",
+						"@babel/plugin-transform-unicode-regex": "^7.4.4",
+						"@babel/types": "^7.6.0",
+						"browserslist": "^4.6.0",
+						"core-js-compat": "^3.1.1",
 						"invariant": "^2.2.2",
 						"js-levenshtein": "^1.1.3",
-						"semver": "^5.3.0"
+						"semver": "^5.5.0"
 					}
 				},
 				"@babel/preset-react": {
@@ -7472,21 +8408,51 @@
 					}
 				},
 				"@babel/runtime": {
-					"version": "7.3.1",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
-					"integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+					"integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
 					"dev": true,
 					"requires": {
-						"regenerator-runtime": "^0.12.0"
+						"regenerator-runtime": "^0.13.2"
 					}
 				},
-				"babel-plugin-dynamic-import-node": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz",
-					"integrity": "sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==",
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
-						"object.assign": "^4.1.0"
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
 					}
 				},
 				"debug": {
@@ -7505,9 +8471,9 @@
 					"dev": true
 				},
 				"regenerator-runtime": {
-					"version": "0.12.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
 					"dev": true
 				}
 			}
@@ -7723,18 +8689,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/better-queue-memory/-/better-queue-memory-1.0.4.tgz",
 			"integrity": "sha512-SWg5wFIShYffEmJpI6LgbL8/3Dqhku7xI1oEiy6FroP9DbcZlG0ZDjxvPdP9t7hTGW40IpIcC6zVoGT1oxjOuA=="
-		},
-		"bfj": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.1.tgz",
-			"integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
-			"dev": true,
-			"requires": {
-				"bluebird": "^3.5.1",
-				"check-types": "^7.3.0",
-				"hoopy": "^0.1.2",
-				"tryer": "^1.0.0"
-			}
 		},
 		"big.js": {
 			"version": "5.2.2",
@@ -8091,9 +9045,9 @@
 			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
 		"cacache": {
-			"version": "11.3.3",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
-			"integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
+			"version": "12.0.3",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+			"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
 			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.5",
@@ -8101,6 +9055,7 @@
 				"figgy-pudding": "^3.5.1",
 				"glob": "^7.1.4",
 				"graceful-fs": "^4.1.15",
+				"infer-owner": "^1.0.3",
 				"lru-cache": "^5.1.1",
 				"mississippi": "^3.0.0",
 				"mkdirp": "^0.5.1",
@@ -8119,9 +9074,9 @@
 					"dev": true
 				},
 				"glob": {
-					"version": "7.1.5",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
-					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -8226,9 +9181,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001005",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001005.tgz",
-			"integrity": "sha512-g78miZm1Z5njjYR216a5812oPiLgV1ssndgGxITHWUopmjUrCswMisA0a2kSB7a0vZRox6JOKhM51+efmYN8Mg==",
+			"version": "1.0.30001010",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001010.tgz",
+			"integrity": "sha512-RA5GH9YjFNea4ZQszdWgh2SC+dpLiRAg4VDQS2b5JRI45OxmbGrYocYHTa9x0bKMQUE7uvHkNPNffUr+pCxSGw==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -8330,12 +9285,6 @@
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
 		},
-		"check-types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
-			"integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==",
-			"dev": true
-		},
 		"chokidar": {
 			"version": "2.1.8",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -8402,12 +9351,6 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"circular-json": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-			"dev": true
 		},
 		"class-transformer": {
 			"version": "0.2.3",
@@ -8840,6 +9783,15 @@
 			"resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
 			"integrity": "sha1-EdCRMSI5648yyPJa6csAL/6NPCQ="
 		},
+		"compose-function": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/compose-function/-/compose-function-3.0.3.tgz",
+			"integrity": "sha1-ntZ18TzFRQHTCVCkhv9qe6OrGF8=",
+			"dev": true,
+			"requires": {
+				"arity-n": "^1.0.4"
+			}
+		},
 		"compressible": {
 			"version": "2.0.17",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
@@ -9245,9 +10197,9 @@
 			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
 		},
 		"core-js-compat": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.5.tgz",
-			"integrity": "sha512-44ZORuapx0MUht0MUk0p9lcQPh7n/LDXehimTmjCs0CYblpKZcqVd5w0OQDUDq5OQjEbazWObHDQJWvvHYPNTg==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.1.tgz",
+			"integrity": "sha512-YdeJI26gLc0CQJ9asLE5obEgBz2I0+CIgnoTbS2T0d5IPQw/OCgCIFR527RmpduxjrB3gSEHoGOCTq9sigOyfw==",
 			"dev": true,
 			"requires": {
 				"browserslist": "^4.7.2",
@@ -9431,6 +10383,26 @@
 				"randomfill": "^1.0.3"
 			}
 		},
+		"css": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"source-map": "^0.6.1",
+				"source-map-resolve": "^0.5.2",
+				"urix": "^0.1.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
 		"css-animation": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.6.1.tgz",
@@ -9447,34 +10419,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.5"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"css-color-keywords": {
@@ -9496,34 +10440,6 @@
 			"requires": {
 				"postcss": "^7.0.1",
 				"timsort": "^0.3.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"css-has-pseudo": {
@@ -9536,52 +10452,56 @@
 				"postcss-selector-parser": "^5.0.0-rc.4"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
 					"dev": true
 				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				}
 			}
 		},
 		"css-loader": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
-			"integrity": "sha512-tMXlTYf3mIMt3b0dDCOQFJiVvxbocJ5Ho577WiGPYPZcqVEO218L2iU22pDXzkTZCLDE+9AmGSUkWxeh/nZReA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.1.1.tgz",
+			"integrity": "sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"css-selector-tokenizer": "^0.7.0",
-				"icss-utils": "^2.1.0",
-				"loader-utils": "^1.0.2",
-				"lodash.camelcase": "^4.3.0",
-				"postcss": "^6.0.23",
-				"postcss-modules-extract-imports": "^1.2.0",
-				"postcss-modules-local-by-default": "^1.2.0",
-				"postcss-modules-scope": "^1.1.0",
-				"postcss-modules-values": "^1.3.0",
+				"camelcase": "^5.2.0",
+				"icss-utils": "^4.1.0",
+				"loader-utils": "^1.2.3",
+				"normalize-path": "^3.0.0",
+				"postcss": "^7.0.14",
+				"postcss-modules-extract-imports": "^2.0.0",
+				"postcss-modules-local-by-default": "^2.0.6",
+				"postcss-modules-scope": "^2.1.0",
+				"postcss-modules-values": "^2.0.0",
 				"postcss-value-parser": "^3.3.0",
-				"source-list-map": "^2.0.0"
+				"schema-utils": "^1.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true
+				}
 			}
 		},
 		"css-prefers-color-scheme": {
@@ -9591,44 +10511,16 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.5"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"css-select": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
-			"integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+			"integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
 			"dev": true,
 			"requires": {
 				"boolbase": "^1.0.0",
-				"css-what": "^2.1.2",
+				"css-what": "^3.2.1",
 				"domutils": "^1.7.0",
 				"nth-check": "^1.0.2"
 			}
@@ -9638,51 +10530,6 @@
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
 			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
 			"dev": true
-		},
-		"css-selector-tokenizer": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
-			"integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
-			"dev": true,
-			"requires": {
-				"cssesc": "^0.1.0",
-				"fastparse": "^1.1.1",
-				"regexpu-core": "^1.0.0"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
-				},
-				"regexpu-core": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-					"dev": true,
-					"requires": {
-						"regenerate": "^1.2.1",
-						"regjsgen": "^0.2.0",
-						"regjsparser": "^0.1.4"
-					}
-				},
-				"regjsgen": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-					"dev": true
-				},
-				"regjsparser": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-					"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-					"dev": true,
-					"requires": {
-						"jsesc": "~0.5.0"
-					}
-				}
-			}
 		},
 		"css-to-react-native": {
 			"version": "2.3.2",
@@ -9695,13 +10542,21 @@
 			}
 		},
 		"css-tree": {
-			"version": "1.0.0-alpha.33",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
-			"integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
+			"version": "1.0.0-alpha.37",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+			"integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
 			"dev": true,
 			"requires": {
 				"mdn-data": "2.0.4",
-				"source-map": "^0.5.3"
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
 			}
 		},
 		"css-unit-converter": {
@@ -9711,9 +10566,9 @@
 			"dev": true
 		},
 		"css-what": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
+			"integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==",
 			"dev": true
 		},
 		"cssdb": {
@@ -9723,9 +10578,9 @@
 			"dev": true
 		},
 		"cssesc": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
 			"dev": true
 		},
 		"cssnano": {
@@ -9738,34 +10593,6 @@
 				"cssnano-preset-default": "^4.0.7",
 				"is-resolvable": "^1.0.0",
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"cssnano-preset-default": {
@@ -9804,34 +10631,6 @@
 				"postcss-reduce-transforms": "^4.0.2",
 				"postcss-svgo": "^4.0.2",
 				"postcss-unique-selectors": "^4.0.1"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"cssnano-util-get-arguments": {
@@ -9853,34 +10652,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"cssnano-util-same-parent": {
@@ -9890,30 +10661,12 @@
 			"dev": true
 		},
 		"csso": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
-			"integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz",
+			"integrity": "sha512-kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==",
 			"dev": true,
 			"requires": {
-				"css-tree": "1.0.0-alpha.29"
-			},
-			"dependencies": {
-				"css-tree": {
-					"version": "1.0.0-alpha.29",
-					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
-					"integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
-					"dev": true,
-					"requires": {
-						"mdn-data": "~1.1.0",
-						"source-map": "^0.5.3"
-					}
-				},
-				"mdn-data": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-					"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-					"dev": true
-				}
+				"css-tree": "1.0.0-alpha.37"
 			}
 		},
 		"cssom": {
@@ -9958,6 +10711,16 @@
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
 			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
 			"dev": true
+		},
+		"d": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+			"dev": true,
+			"requires": {
+				"es5-ext": "^0.10.50",
+				"type": "^1.0.1"
+			}
 		},
 		"damerau-levenshtein": {
 			"version": "1.0.5",
@@ -10056,9 +10819,9 @@
 			"dev": true
 		},
 		"deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
-			"integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+			"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
 			"dev": true,
 			"requires": {
 				"is-arguments": "^1.0.4",
@@ -10094,61 +10857,20 @@
 			"integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
 		},
 		"default-gateway": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
-			"integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
+			"integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
 			"dev": true,
 			"requires": {
-				"execa": "^0.10.0",
+				"execa": "^1.0.0",
 				"ip-regex": "^2.1.0"
 			},
 			"dependencies": {
-				"execa": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
-				},
 				"ip-regex": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
 					"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
 					"dev": true
-				}
-			}
-		},
-		"default-require-extensions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-			"dev": true,
-			"requires": {
-				"strip-bom": "^2.0.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
 				}
 			}
 		},
@@ -10274,9 +10996,9 @@
 			"dev": true
 		},
 		"des.js": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+			"integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
 			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
@@ -10477,9 +11199,9 @@
 			"integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4="
 		},
 		"dom-serializer": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
-			"integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
 			"dev": true,
 			"requires": {
 				"domelementtype": "^2.0.1",
@@ -10558,9 +11280,9 @@
 			"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
 		},
 		"dotenv-expand": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
-			"integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+			"integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
 			"dev": true
 		},
 		"draft-js": {
@@ -10614,9 +11336,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.296",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.296.tgz",
-			"integrity": "sha512-s5hv+TSJSVRsxH190De66YHb50pBGTweT9XGWYu/LMR20KX6TsjFzObo36CjVAzM+PUeeKSBRtm/mISlCzeojQ==",
+			"version": "1.3.306",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.306.tgz",
+			"integrity": "sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -10784,6 +11506,28 @@
 				"is-symbol": "^1.0.2"
 			}
 		},
+		"es5-ext": {
+			"version": "0.10.52",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
+			"integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
+			"dev": true,
+			"requires": {
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.2",
+				"next-tick": "~1.0.0"
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"dev": true,
+			"requires": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
 		"es6-promise": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -10797,6 +11541,16 @@
 			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+			"dev": true,
+			"requires": {
+				"d": "^1.0.1",
+				"ext": "^1.1.2"
 			}
 		},
 		"escape-html": {
@@ -11144,12 +11898,12 @@
 			}
 		},
 		"eslint-config-react-app": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-3.0.8.tgz",
-			"integrity": "sha512-Ovi6Bva67OjXrom9Y/SLJRkrGqKhMAL0XCH8BizPhjEVEhYczl2ZKiNZI2CuqO5/CJwAfMwRXAVGY0KToWr1aA==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.0.2.tgz",
+			"integrity": "sha512-VhlESAQM83uULJ9jsvcKxx2Ab0yrmjUt8kDz5DyhTQufqWE0ssAnejlWri5LXv25xoXfdqOyeDPdfJS9dXKagQ==",
 			"dev": true,
 			"requires": {
-				"confusing-browser-globals": "^1.0.6"
+				"confusing-browser-globals": "^1.0.9"
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -11163,16 +11917,57 @@
 			}
 		},
 		"eslint-loader": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.1.1.tgz",
-			"integrity": "sha512-1GrJFfSevQdYpoDzx8mEE2TDWsb/zmFuY09l6hURg1AeFIKQOvZ+vH0UPjzmd1CZIbfTV5HUkMeBmFiDBkgIsQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-3.0.2.tgz",
+			"integrity": "sha512-S5VnD+UpVY1PyYRqeBd/4pgsmkvSokbHqTXAQMpvCyRr3XN2tvSLo9spm2nEpqQqh9dezw3os/0zWihLeOg2Rw==",
 			"dev": true,
 			"requires": {
-				"loader-fs-cache": "^1.0.0",
-				"loader-utils": "^1.0.2",
-				"object-assign": "^4.0.1",
-				"object-hash": "^1.1.4",
-				"rimraf": "^2.6.1"
+				"fs-extra": "^8.1.0",
+				"loader-fs-cache": "^1.0.2",
+				"loader-utils": "^1.2.3",
+				"object-hash": "^1.3.1",
+				"schema-utils": "^2.2.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+					"dev": true
+				},
+				"schema-utils": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.5.0.tgz",
+					"integrity": "sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
+					}
+				}
 			}
 		},
 		"eslint-module-utils": {
@@ -11197,30 +11992,31 @@
 			}
 		},
 		"eslint-plugin-flowtype": {
-			"version": "2.50.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.1.tgz",
-			"integrity": "sha512-9kRxF9hfM/O6WGZcZPszOVPd2W0TLHBtceulLTsGfwMPtiCCLnCW0ssRiOOiXyqrCA20pm1iXdXm7gQeN306zQ==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.13.0.tgz",
+			"integrity": "sha512-bhewp36P+t7cEV0b6OdmoRWJCBYRiHFlqPZAG1oS3SF+Y0LQkeDvFSM4oxoxvczD1OdONCXMlJfQFiWLcV9urw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.15"
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
-			"integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+			"version": "2.18.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+			"integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
 			"dev": true,
 			"requires": {
+				"array-includes": "^3.0.3",
 				"contains-path": "^0.1.0",
-				"debug": "^2.6.8",
+				"debug": "^2.6.9",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "^0.3.1",
-				"eslint-module-utils": "^2.2.0",
-				"has": "^1.0.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.3",
+				"eslint-import-resolver-node": "^0.3.2",
+				"eslint-module-utils": "^2.4.0",
+				"has": "^1.0.3",
+				"minimatch": "^3.0.4",
+				"object.values": "^1.1.0",
 				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.6.0"
+				"resolve": "^1.11.0"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -11289,46 +12085,50 @@
 						"find-up": "^2.0.0",
 						"read-pkg": "^2.0.0"
 					}
+				},
+				"resolve": {
+					"version": "1.12.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+					"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
 				}
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.2.tgz",
-			"integrity": "sha512-7gSSmwb3A+fQwtw0arguwMdOdzmKUgnUcbSNlo+GjKLAQFuC2EZxWqG9XHRI8VscBJD5a8raz3RuxQNFW+XJbw==",
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+			"integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
 			"dev": true,
 			"requires": {
+				"@babel/runtime": "^7.4.5",
 				"aria-query": "^3.0.0",
 				"array-includes": "^3.0.3",
 				"ast-types-flow": "^0.0.7",
-				"axobject-query": "^2.0.1",
+				"axobject-query": "^2.0.2",
 				"damerau-levenshtein": "^1.0.4",
-				"emoji-regex": "^6.5.1",
+				"emoji-regex": "^7.0.2",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.0.1"
-			},
-			"dependencies": {
-				"emoji-regex": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-					"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
-					"dev": true
-				}
+				"jsx-ast-utils": "^2.2.1"
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.12.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
-			"integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
+			"version": "7.14.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+			"integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.0.3",
 				"doctrine": "^2.1.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.0.1",
+				"jsx-ast-utils": "^2.1.0",
+				"object.entries": "^1.1.0",
 				"object.fromentries": "^2.0.0",
-				"prop-types": "^15.6.2",
-				"resolve": "^1.9.0"
+				"object.values": "^1.1.0",
+				"prop-types": "^15.7.2",
+				"resolve": "^1.10.1"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -11338,6 +12138,15 @@
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2"
+					}
+				},
+				"resolve": {
+					"version": "1.12.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+					"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
 					}
 				}
 			}
@@ -11349,9 +12158,9 @@
 			"dev": true
 		},
 		"eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+			"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
@@ -11372,25 +12181,6 @@
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
 			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
 			"dev": true
-		},
-		"espree": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-			"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
-			"dev": true,
-			"requires": {
-				"acorn": "^6.0.7",
-				"acorn-jsx": "^5.0.0",
-				"eslint-visitor-keys": "^1.0.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
-					"dev": true
-				}
-			}
 		},
 		"esprima": {
 			"version": "4.0.1",
@@ -11663,6 +12453,23 @@
 				}
 			}
 		},
+		"ext": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.2.0.tgz",
+			"integrity": "sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==",
+			"dev": true,
+			"requires": {
+				"type": "^2.0.0"
+			},
+			"dependencies": {
+				"type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+					"integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+					"dev": true
+				}
+			}
+		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -11828,12 +12635,6 @@
 			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
 			"dev": true
 		},
-		"fastparse": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
-			"integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
-			"dev": true
-		},
 		"faye-websocket": {
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
@@ -11894,20 +12695,10 @@
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
-		"file-entry-cache": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-			"dev": true,
-			"requires": {
-				"flat-cache": "^1.2.1",
-				"object-assign": "^4.0.1"
-			}
-		},
 		"file-loader": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
-			"integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
+			"integrity": "sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.0.2",
@@ -11927,16 +12718,6 @@
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
 			"dev": true
-		},
-		"fileset": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
-			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-			"dev": true,
-			"requires": {
-				"glob": "^7.0.3",
-				"minimatch": "^3.0.3"
-			}
 		},
 		"filesize": {
 			"version": "3.6.1",
@@ -12007,18 +12788,6 @@
 				"locate-path": "^2.0.0"
 			}
 		},
-		"flat-cache": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-			"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
-			"dev": true,
-			"requires": {
-				"circular-json": "^0.3.1",
-				"graceful-fs": "^4.1.2",
-				"rimraf": "~2.6.2",
-				"write": "^0.2.1"
-			}
-		},
 		"flatted": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
@@ -12026,9 +12795,9 @@
 			"dev": true
 		},
 		"flatten": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
+			"integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
 			"dev": true
 		},
 		"flexbox-react": {
@@ -12157,9 +12926,9 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"fork-ts-checker-webpack-plugin": {
-			"version": "1.0.0-alpha.6",
-			"resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.0.0-alpha.6.tgz",
-			"integrity": "sha512-s/V+58nLrUjuXyzYk8AL11XG8bxIirTbafDLMn26sL59HQx8QvvsRTqOkhq4MV0coIkog1jZuH/E9Abm8zFZ2g==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.5.0.tgz",
+			"integrity": "sha512-zEhg7Hz+KhZlBhILYpXy+Beu96gwvkROWJiTXOCyOOMMrdBIRPvsBpBqgTI4jfJGrJXcqGwJR8zsBGDmzY0jsA==",
 			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.22.0",
@@ -12168,7 +12937,8 @@
 				"micromatch": "^3.1.10",
 				"minimatch": "^3.0.4",
 				"semver": "^5.6.0",
-				"tapable": "^1.0.0"
+				"tapable": "^1.0.0",
+				"worker-rpc": "^0.1.0"
 			}
 		},
 		"form-data": {
@@ -13458,13 +14228,21 @@
 			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
 		},
 		"gzip-size": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
-			"integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+			"integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
 			"dev": true,
 			"requires": {
 				"duplexer": "^0.1.1",
-				"pify": "^3.0.0"
+				"pify": "^4.0.1"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				}
 			}
 		},
 		"hammerjs": {
@@ -13647,12 +14425,6 @@
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
-		"hoek": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-			"dev": true
-		},
 		"hoist-non-react-statics": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
@@ -13670,12 +14442,6 @@
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.1"
 			}
-		},
-		"hoopy": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
-			"integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
-			"dev": true
 		},
 		"hosted-git-info": {
 			"version": "2.7.1",
@@ -13744,17 +14510,16 @@
 			}
 		},
 		"html-webpack-plugin": {
-			"version": "4.0.0-alpha.2",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-alpha.2.tgz",
-			"integrity": "sha512-tyvhjVpuGqD7QYHi1l1drMQTg5i+qRxpQEGbdnYFREgOKy7aFDf/ocQ/V1fuEDlQx7jV2zMap3Hj2nE9i5eGXw==",
+			"version": "4.0.0-beta.5",
+			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.5.tgz",
+			"integrity": "sha512-y5l4lGxOW3pz3xBTFdfB9rnnrWRPVxlAhX6nrBYIcW+2k2zC3mSp/3DxlWVCMBfnO6UAnoF8OcFn0IMy6kaKAQ==",
 			"dev": true,
 			"requires": {
-				"@types/tapable": "1.0.2",
-				"html-minifier": "^3.2.3",
+				"html-minifier": "^3.5.20",
 				"loader-utils": "^1.1.0",
-				"lodash": "^4.17.10",
-				"pretty-error": "^2.0.2",
-				"tapable": "^1.0.0",
+				"lodash": "^4.17.11",
+				"pretty-error": "^2.1.1",
+				"tapable": "^1.1.0",
 				"util.promisify": "1.0.0"
 			}
 		},
@@ -13906,15 +14671,15 @@
 			}
 		},
 		"http-proxy-middleware": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
-			"integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+			"integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
 			"dev": true,
 			"requires": {
-				"http-proxy": "^1.16.2",
+				"http-proxy": "^1.17.0",
 				"is-glob": "^4.0.0",
-				"lodash": "^4.17.5",
-				"micromatch": "^3.1.9"
+				"lodash": "^4.17.11",
+				"micromatch": "^3.1.10"
 			},
 			"dependencies": {
 				"is-glob": {
@@ -14001,12 +14766,12 @@
 			"dev": true
 		},
 		"icss-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
-			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+			"integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.14"
 			}
 		},
 		"id3-parser": {
@@ -14113,24 +14878,13 @@
 			}
 		},
 		"import-local": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^2.0.0",
+				"pkg-dir": "^3.0.0",
 				"resolve-cwd": "^2.0.0"
-			},
-			"dependencies": {
-				"pkg-dir": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.1.0"
-					}
-				}
 			}
 		},
 		"imurmurhash": {
@@ -14272,13 +15026,13 @@
 			}
 		},
 		"internal-ip": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
-			"integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
+			"integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
 			"dev": true,
 			"requires": {
-				"default-gateway": "^2.6.0",
-				"ipaddr.js": "^1.5.2"
+				"default-gateway": "^4.2.0",
+				"ipaddr.js": "^1.9.0"
 			}
 		},
 		"interpret": {
@@ -14634,9 +15388,9 @@
 			"dev": true
 		},
 		"is-root": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-root/-/is-root-2.0.0.tgz",
-			"integrity": "sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
+			"integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==",
 			"dev": true
 		},
 		"is-ssh": {
@@ -14721,15 +15475,6 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
-		"isemail": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-			"integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-			"dev": true,
-			"requires": {
-				"punycode": "2.x.x"
-			}
-		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -14766,126 +15511,11 @@
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
-		"istanbul-api": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
-			"integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
-			"dev": true,
-			"requires": {
-				"async": "^2.1.4",
-				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.2.1",
-				"istanbul-lib-hook": "^1.2.2",
-				"istanbul-lib-instrument": "^1.10.2",
-				"istanbul-lib-report": "^1.1.5",
-				"istanbul-lib-source-maps": "^1.2.6",
-				"istanbul-reports": "^1.5.1",
-				"js-yaml": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"once": "^1.4.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
-				"istanbul-lib-coverage": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-					"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
-					"dev": true
-				},
-				"istanbul-lib-instrument": {
-					"version": "1.10.2",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
-					"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
-					"dev": true,
-					"requires": {
-						"babel-generator": "^6.18.0",
-						"babel-template": "^6.16.0",
-						"babel-traverse": "^6.18.0",
-						"babel-types": "^6.18.0",
-						"babylon": "^6.18.0",
-						"istanbul-lib-coverage": "^1.2.1",
-						"semver": "^5.3.0"
-					}
-				},
-				"istanbul-lib-report": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
-					"integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
-					"dev": true,
-					"requires": {
-						"istanbul-lib-coverage": "^1.2.1",
-						"mkdirp": "^0.5.1",
-						"path-parse": "^1.0.5",
-						"supports-color": "^3.1.2"
-					}
-				},
-				"istanbul-lib-source-maps": {
-					"version": "1.2.6",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
-					"integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
-					"dev": true,
-					"requires": {
-						"debug": "^3.1.0",
-						"istanbul-lib-coverage": "^1.2.1",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.6.1",
-						"source-map": "^0.5.3"
-					}
-				},
-				"istanbul-reports": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
-					"integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
-					"dev": true,
-					"requires": {
-						"handlebars": "^4.0.3"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
-			}
-		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
 			"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
 			"dev": true
-		},
-		"istanbul-lib-hook": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
-			"integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
-			"dev": true,
-			"requires": {
-				"append-transform": "^0.4.0"
-			}
 		},
 		"istanbul-lib-instrument": {
 			"version": "3.3.0",
@@ -15300,6 +15930,84 @@
 				"jest-mock": "^24.9.0",
 				"jest-util": "^24.9.0",
 				"jsdom": "^11.5.1"
+			}
+		},
+		"jest-environment-jsdom-fourteen": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom-fourteen/-/jest-environment-jsdom-fourteen-0.1.0.tgz",
+			"integrity": "sha512-4vtoRMg7jAstitRzL4nbw83VmGH8Rs13wrND3Ud2o1fczDhMUF32iIrNKwYGgeOPUdfvZU4oy8Bbv+ni1fgVCA==",
+			"dev": true,
+			"requires": {
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jsdom": "^14.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+					"dev": true
+				},
+				"jsdom": {
+					"version": "14.1.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-14.1.0.tgz",
+					"integrity": "sha512-O901mfJSuTdwU2w3Sn+74T+RnDVP+FuV5fH8tcPWyqrseRAb0s5xOtPgCFiPOtLcyK7CLIJwPyD83ZqQWvA5ng==",
+					"dev": true,
+					"requires": {
+						"abab": "^2.0.0",
+						"acorn": "^6.0.4",
+						"acorn-globals": "^4.3.0",
+						"array-equal": "^1.0.0",
+						"cssom": "^0.3.4",
+						"cssstyle": "^1.1.1",
+						"data-urls": "^1.1.0",
+						"domexception": "^1.0.1",
+						"escodegen": "^1.11.0",
+						"html-encoding-sniffer": "^1.0.2",
+						"nwsapi": "^2.1.3",
+						"parse5": "5.1.0",
+						"pn": "^1.1.0",
+						"request": "^2.88.0",
+						"request-promise-native": "^1.0.5",
+						"saxes": "^3.1.9",
+						"symbol-tree": "^3.2.2",
+						"tough-cookie": "^2.5.0",
+						"w3c-hr-time": "^1.0.1",
+						"w3c-xmlserializer": "^1.1.2",
+						"webidl-conversions": "^4.0.2",
+						"whatwg-encoding": "^1.0.5",
+						"whatwg-mimetype": "^2.3.0",
+						"whatwg-url": "^7.0.0",
+						"ws": "^6.1.2",
+						"xml-name-validator": "^3.0.0"
+					}
+				},
+				"parse5": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
+				},
+				"ws": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
 			}
 		},
 		"jest-environment-node": {
@@ -16857,41 +17565,49 @@
 			}
 		},
 		"jest-watch-typeahead": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-0.2.1.tgz",
-			"integrity": "sha512-xdhEtKSj0gmnkDQbPTIHvcMmXNUDzYpHLEJ5TFqlaI+schi2NI96xhWiZk9QoesAS7oBmKwWWsHazTrYl2ORgg==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-0.4.0.tgz",
+			"integrity": "sha512-bJR/HPNgOQnkmttg1OkBIrYFAYuxFxExtgQh67N2qPvaWGVC8TCkedRNPKBfmZfVXFD3u2sCH+9OuS5ApBfCgA==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
+				"ansi-escapes": "^4.2.1",
 				"chalk": "^2.4.1",
-				"jest-watcher": "^23.1.0",
-				"slash": "^2.0.0",
-				"string-length": "^2.0.0",
+				"jest-watcher": "^24.3.0",
+				"slash": "^3.0.0",
+				"string-length": "^3.1.0",
 				"strip-ansi": "^5.0.0"
 			},
 			"dependencies": {
+				"ansi-escapes": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+					"integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.5.2"
+					}
+				},
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
-				"jest-watcher": {
-					"version": "23.4.0",
-					"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
-					"integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"string-length": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+					"integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.1",
-						"string-length": "^2.0.0"
+						"astral-regex": "^1.0.0",
+						"strip-ansi": "^5.2.0"
 					}
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
 				},
 				"strip-ansi": {
 					"version": "5.2.0",
@@ -16901,6 +17617,12 @@
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					}
+				},
+				"type-fest": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+					"integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+					"dev": true
 				}
 			}
 		},
@@ -16950,17 +17672,6 @@
 			"version": "0.15.0",
 			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
 			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-		},
-		"joi": {
-			"version": "11.4.0",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
-			"integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
-			"dev": true,
-			"requires": {
-				"hoek": "4.x.x",
-				"isemail": "3.x.x",
-				"topo": "2.x.x"
-			}
 		},
 		"js-levenshtein": {
 			"version": "1.1.6",
@@ -17582,12 +18293,6 @@
 			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
 			"dev": true
 		},
-		"lodash.camelcase": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-			"dev": true
-		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -17684,12 +18389,6 @@
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-		},
-		"lodash.tail": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
-			"integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
-			"dev": true
 		},
 		"lodash.template": {
 			"version": "4.5.0",
@@ -17845,9 +18544,9 @@
 			}
 		},
 		"loglevel": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.4.tgz",
-			"integrity": "sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==",
+			"version": "1.6.6",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
+			"integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
 			"dev": true
 		},
 		"lokijs": {
@@ -18003,6 +18702,12 @@
 			"requires": {
 				"tmpl": "1.0.x"
 			}
+		},
+		"mamacro": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
+			"integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
+			"dev": true
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -18199,6 +18904,12 @@
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
+		"microevent.ts": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
+			"integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==",
+			"dev": true
+		},
 		"micromatch": {
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -18236,9 +18947,9 @@
 			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
 		},
 		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+			"integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
 			"dev": true
 		},
 		"mime-types": {
@@ -18273,14 +18984,38 @@
 			}
 		},
 		"mini-css-extract-plugin": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz",
-			"integrity": "sha512-IuaLjruM0vMKhUUT51fQdQzBYTX49dLj8w68ALEAe2A4iYNpIC4eMac67mt3NzycvjOlf07/kYxJDc0RTl1Wqw==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz",
+			"integrity": "sha512-MNpRGbNA52q6U92i0qbVpQNsgk7LExy41MdAlG84FeytfDOtRIf/mCHdEgG8rpTKOaNKiqUnZdlptF469hxqOw==",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",
+				"normalize-url": "1.9.1",
 				"schema-utils": "^1.0.0",
 				"webpack-sources": "^1.1.0"
+			},
+			"dependencies": {
+				"normalize-url": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+					"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+					"dev": true,
+					"requires": {
+						"object-assign": "^4.0.1",
+						"prepend-http": "^1.0.0",
+						"query-string": "^4.1.0",
+						"sort-keys": "^1.0.0"
+					}
+				},
+				"sort-keys": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+					"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+					"dev": true,
+					"requires": {
+						"is-plain-obj": "^1.0.0"
+					}
+				}
 			}
 		},
 		"mini-store": {
@@ -18625,6 +19360,12 @@
 			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
 			"dev": true
 		},
+		"next-tick": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+			"dev": true
+		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -18771,6 +19512,15 @@
 							"dev": true
 						}
 					}
+				},
+				"util": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+					"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
 				}
 			}
 		},
@@ -18779,19 +19529,6 @@
 			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
 			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
 			"dev": true
-		},
-		"node-notifier": {
-			"version": "5.4.3",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-			"integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
-			"dev": true,
-			"requires": {
-				"growly": "^1.3.0",
-				"is-wsl": "^1.1.0",
-				"semver": "^5.5.0",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
-			}
 		},
 		"node-pre-gyp": {
 			"version": "0.13.0",
@@ -18822,9 +19559,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.39",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
-			"integrity": "sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==",
+			"version": "1.1.40",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.40.tgz",
+			"integrity": "sha512-r4LPcC5b/bS8BdtWH1fbeK88ib/wg9aqmg6/s3ngNLn2Ewkn/8J6Iw3P9RTlfIAdSdvYvQl2thCY5Y+qTAQ2iQ==",
 			"dev": true,
 			"requires": {
 				"semver": "^6.3.0"
@@ -19027,9 +19764,9 @@
 			"dev": true
 		},
 		"object-inspect": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
 			"dev": true
 		},
 		"object-is": {
@@ -19067,6 +19804,18 @@
 				"function-bind": "^1.1.1",
 				"has-symbols": "^1.0.0",
 				"object-keys": "^1.0.11"
+			}
+		},
+		"object.entries": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+			"integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.12.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
 			}
 		},
 		"object.fromentries": {
@@ -19203,10 +19952,19 @@
 				"mimic-fn": "^1.0.0"
 			}
 		},
+		"open": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+			"integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+			"dev": true,
+			"requires": {
+				"is-wsl": "^1.1.0"
+			}
+		},
 		"opn": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-			"integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+			"integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
 			"dev": true,
 			"requires": {
 				"is-wsl": "^1.1.0"
@@ -19239,12 +19997,12 @@
 			}
 		},
 		"optimize-css-assets-webpack-plugin": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz",
-			"integrity": "sha512-Rqm6sSjWtx9FchdP0uzTQDc7GXDKnwVEGoSxjezPkzMewx7gEWE9IMUYKmigTRC4U3RaNSwYVnUDLuIdtTpm0A==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.3.tgz",
+			"integrity": "sha512-q9fbvCRS6EYtUKKSwI87qm2IxlyJK5b4dygW1rKUBT6mMDhdG5e5bZT63v6tnJR9F9FB/H5a0HTmtw+laUBxKA==",
 			"dev": true,
 			"requires": {
-				"cssnano": "^4.1.0",
+				"cssnano": "^4.1.10",
 				"last-call-webpack-plugin": "^3.0.0"
 			}
 		},
@@ -19827,12 +20585,6 @@
 				"find-up": "^2.1.0"
 			}
 		},
-		"pluralize": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-			"dev": true
-		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -19840,12 +20592,12 @@
 			"dev": true
 		},
 		"pnp-webpack-plugin": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.2.1.tgz",
-			"integrity": "sha512-W6GctK7K2qQiVR+gYSv/Gyt6jwwIH4vwdviFqx+Y2jAtVf5eZyYIDf5Ac2NCDMBiX5yWscBLZElPTsyA1UtVVA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.5.0.tgz",
+			"integrity": "sha512-jd9olUr9D7do+RN8Wspzhpxhgp1n6Vd0NtQ4SFkmIACZoEL1nkyAdW9Ygrinjec0vgDcWjscFQQ1gDW8rsfKTg==",
 			"dev": true,
 			"requires": {
-				"ts-pnp": "^1.0.0"
+				"ts-pnp": "^1.1.2"
 			}
 		},
 		"portfinder": {
@@ -19883,45 +20635,16 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "6.0.23",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-			"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+			"version": "7.0.21",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
+			"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
+				"chalk": "^2.4.2",
 				"source-map": "^0.6.1",
-				"supports-color": "^5.4.0"
+				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"postcss-attribute-case-insensitive": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
-			"integrity": "sha512-L2YKB3vF4PetdTIthQVeT+7YiSzMoNMLLYxPXXppOOP7NoazEAy45sh2LvJ8leCQjfBcfkYQs8TtCcQjeZTp8A==",
-			"dev": true,
-			"requires": {
-				"postcss": "^7.0.2",
-				"postcss-selector-parser": "^5.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -19937,6 +20660,44 @@
 						"has-flag": "^3.0.0"
 					}
 				}
+			}
+		},
+		"postcss-attribute-case-insensitive": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
+			"integrity": "sha512-L2YKB3vF4PetdTIthQVeT+7YiSzMoNMLLYxPXXppOOP7NoazEAy45sh2LvJ8leCQjfBcfkYQs8TtCcQjeZTp8A==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-selector-parser": "^5.0.0"
+			},
+			"dependencies": {
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+					"dev": true
+				},
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+					"dev": true,
+					"requires": {
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				}
+			}
+		},
+		"postcss-browser-comments": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-2.0.0.tgz",
+			"integrity": "sha512-xGG0UvoxwBc4Yx4JX3gc0RuDl1kc4bVihCzzk6UC72YPfq5fu3c717Nu8Un3nvnq1BJ31gBnFXIG/OaUTnpHgA==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.2"
 			}
 		},
 		"postcss-calc": {
@@ -19951,30 +20712,21 @@
 				"postcss-value-parser": "^3.3.1"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
 					"dev": true
 				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				}
 			}
@@ -19987,34 +20739,6 @@
 			"requires": {
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-color-gray": {
@@ -20026,34 +20750,6 @@
 				"@csstools/convert-colors": "^1.4.0",
 				"postcss": "^7.0.5",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-color-hex-alpha": {
@@ -20064,34 +20760,6 @@
 			"requires": {
 				"postcss": "^7.0.14",
 				"postcss-values-parser": "^2.0.1"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-color-mod-function": {
@@ -20103,34 +20771,6 @@
 				"@csstools/convert-colors": "^1.4.0",
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-color-rebeccapurple": {
@@ -20141,34 +20781,6 @@
 			"requires": {
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-colormin": {
@@ -20182,34 +20794,6 @@
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-convert-values": {
@@ -20220,34 +20804,6 @@
 			"requires": {
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-custom-media": {
@@ -20257,34 +20813,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.14"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-custom-properties": {
@@ -20295,34 +20823,6 @@
 			"requires": {
 				"postcss": "^7.0.17",
 				"postcss-values-parser": "^2.0.1"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-custom-selectors": {
@@ -20335,30 +20835,21 @@
 				"postcss-selector-parser": "^5.0.0-rc.3"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
 					"dev": true
 				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				}
 			}
@@ -20373,30 +20864,21 @@
 				"postcss-selector-parser": "^5.0.0-rc.3"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
 					"dev": true
 				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				}
 			}
@@ -20408,34 +20890,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-discard-duplicates": {
@@ -20445,34 +20899,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-discard-empty": {
@@ -20482,34 +20908,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-discard-overridden": {
@@ -20519,34 +20917,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-double-position-gradients": {
@@ -20557,34 +20927,6 @@
 			"requires": {
 				"postcss": "^7.0.5",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-env-function": {
@@ -20595,34 +20937,6 @@
 			"requires": {
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-flexbugs-fixes": {
@@ -20632,34 +20946,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-focus-visible": {
@@ -20669,34 +20955,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-focus-within": {
@@ -20706,34 +20964,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-font-variant": {
@@ -20743,34 +20973,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-gap-properties": {
@@ -20780,34 +20982,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-image-set-function": {
@@ -20818,72 +20992,16 @@
 			"requires": {
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-initial": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.1.tgz",
-			"integrity": "sha512-I2Sz83ZSHybMNh02xQDK609lZ1/QOyYeuizCjzEhlMgeV/HcDJapQiH4yTqLjZss0X6/6VvKFXUeObaHpJoINw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.2.tgz",
+			"integrity": "sha512-ugA2wKonC0xeNHgirR4D3VWHs2JcU08WAi1KFLVcnb7IN89phID6Qtg2RIctWbnvp1TM2BOmDtX8GGLCKdR8YA==",
 			"dev": true,
 			"requires": {
 				"lodash.template": "^4.5.0",
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-lab-function": {
@@ -20895,34 +21013,6 @@
 				"@csstools/convert-colors": "^1.4.0",
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-load-config": {
@@ -20945,34 +21035,6 @@
 				"postcss": "^7.0.0",
 				"postcss-load-config": "^2.0.0",
 				"schema-utils": "^1.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-logical": {
@@ -20982,34 +21044,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-media-minmax": {
@@ -21019,34 +21053,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-merge-longhand": {
@@ -21059,34 +21065,6 @@
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0",
 				"stylehacks": "^4.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-merge-rules": {
@@ -21103,17 +21081,6 @@
 				"vendors": "^1.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"postcss-selector-parser": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -21123,21 +21090,6 @@
 						"dot-prop": "^4.1.1",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -21150,34 +21102,6 @@
 			"requires": {
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-minify-gradients": {
@@ -21190,34 +21114,6 @@
 				"is-color-stop": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-minify-params": {
@@ -21232,34 +21128,6 @@
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0",
 				"uniqs": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-minify-selectors": {
@@ -21274,17 +21142,6 @@
 				"postcss-selector-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"postcss-selector-parser": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -21295,61 +21152,47 @@
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
 		"postcss-modules-extract-imports": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
-			"integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+			"integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.5"
 			}
 		},
 		"postcss-modules-local-by-default": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
-			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
+			"integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
 			"dev": true,
 			"requires": {
-				"css-selector-tokenizer": "^0.7.0",
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.6",
+				"postcss-selector-parser": "^6.0.0",
+				"postcss-value-parser": "^3.3.1"
 			}
 		},
 		"postcss-modules-scope": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
-			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
+			"integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
 			"dev": true,
 			"requires": {
-				"css-selector-tokenizer": "^0.7.0",
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.6",
+				"postcss-selector-parser": "^6.0.0"
 			}
 		},
 		"postcss-modules-values": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
-			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
+			"integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
 			"dev": true,
 			"requires": {
 				"icss-replace-symbols": "^1.1.0",
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.6"
 			}
 		},
 		"postcss-nesting": {
@@ -21359,34 +21202,18 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+			}
+		},
+		"postcss-normalize": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize/-/postcss-normalize-7.0.1.tgz",
+			"integrity": "sha512-NOp1fwrG+6kVXWo7P9SizCHX6QvioxFD/hZcI2MLxPmVnFJFC0j0DDpIuNw2tUDeCFMni59gCVgeJ1/hYhj2OQ==",
+			"dev": true,
+			"requires": {
+				"@csstools/normalize.css": "^9.0.1",
+				"browserslist": "^4.1.1",
+				"postcss": "^7.0.2",
+				"postcss-browser-comments": "^2.0.0"
 			}
 		},
 		"postcss-normalize-charset": {
@@ -21396,34 +21223,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-display-values": {
@@ -21435,34 +21234,6 @@
 				"cssnano-util-get-match": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-positions": {
@@ -21475,34 +21246,6 @@
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-repeat-style": {
@@ -21515,34 +21258,6 @@
 				"cssnano-util-get-match": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-string": {
@@ -21554,34 +21269,6 @@
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-timing-functions": {
@@ -21593,34 +21280,6 @@
 				"cssnano-util-get-match": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-unicode": {
@@ -21632,34 +21291,6 @@
 				"browserslist": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-url": {
@@ -21672,34 +21303,6 @@
 				"normalize-url": "^3.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-whitespace": {
@@ -21710,34 +21313,6 @@
 			"requires": {
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-ordered-values": {
@@ -21749,34 +21324,6 @@
 				"cssnano-util-get-arguments": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-overflow-shorthand": {
@@ -21786,34 +21333,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-page-break": {
@@ -21823,34 +21342,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-place": {
@@ -21861,58 +21352,30 @@
 			"requires": {
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-preset-env": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.5.0.tgz",
-			"integrity": "sha512-RdsIrYJd9p9AouQoJ8dFP5ksBJEIegA4q4WzJDih8nevz3cZyIP/q1Eaw3pTVpUAu3n7Y32YmvAW3X07mSRGkw==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz",
+			"integrity": "sha512-eU4/K5xzSFwUFJ8hTdTQzo2RBLbDVt83QZrAvI07TULOkmyQlnYlpwep+2yIK+K+0KlZO4BvFcleOCCcUtwchg==",
 			"dev": true,
 			"requires": {
-				"autoprefixer": "^9.4.2",
-				"browserslist": "^4.3.5",
-				"caniuse-lite": "^1.0.30000918",
+				"autoprefixer": "^9.6.1",
+				"browserslist": "^4.6.4",
+				"caniuse-lite": "^1.0.30000981",
 				"css-blank-pseudo": "^0.1.4",
 				"css-has-pseudo": "^0.10.0",
 				"css-prefers-color-scheme": "^3.1.1",
-				"cssdb": "^4.3.0",
-				"postcss": "^7.0.6",
-				"postcss-attribute-case-insensitive": "^4.0.0",
+				"cssdb": "^4.4.0",
+				"postcss": "^7.0.17",
+				"postcss-attribute-case-insensitive": "^4.0.1",
 				"postcss-color-functional-notation": "^2.0.1",
 				"postcss-color-gray": "^5.0.0",
-				"postcss-color-hex-alpha": "^5.0.2",
+				"postcss-color-hex-alpha": "^5.0.3",
 				"postcss-color-mod-function": "^3.0.3",
 				"postcss-color-rebeccapurple": "^4.0.1",
-				"postcss-custom-media": "^7.0.7",
-				"postcss-custom-properties": "^8.0.9",
+				"postcss-custom-media": "^7.0.8",
+				"postcss-custom-properties": "^8.0.11",
 				"postcss-custom-selectors": "^5.1.2",
 				"postcss-dir-pseudo-class": "^5.0.0",
 				"postcss-double-position-gradients": "^1.0.0",
@@ -21934,34 +21397,6 @@
 				"postcss-replace-overflow-wrap": "^3.0.0",
 				"postcss-selector-matches": "^4.0.0",
 				"postcss-selector-not": "^4.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-pseudo-class-any-link": {
@@ -21974,30 +21409,21 @@
 				"postcss-selector-parser": "^5.0.0-rc.3"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
 					"dev": true
 				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				}
 			}
@@ -22012,34 +21438,6 @@
 				"caniuse-api": "^3.0.0",
 				"has": "^1.0.0",
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-reduce-transforms": {
@@ -22052,34 +21450,6 @@
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-replace-overflow-wrap": {
@@ -22089,34 +21459,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-safe-parser": {
@@ -22126,34 +21468,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-selector-matches": {
@@ -22164,34 +21478,6 @@
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-selector-not": {
@@ -22202,53 +21488,17 @@
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-selector-parser": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
-			"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+			"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
 			"dev": true,
 			"requires": {
-				"cssesc": "^2.0.0",
+				"cssesc": "^3.0.0",
 				"indexes-of": "^1.0.1",
 				"uniq": "^1.0.1"
-			},
-			"dependencies": {
-				"cssesc": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
-					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
-					"dev": true
-				}
 			}
 		},
 		"postcss-svgo": {
@@ -22261,34 +21511,6 @@
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0",
 				"svgo": "^1.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-unique-selectors": {
@@ -22300,34 +21522,6 @@
 				"alphanum-sort": "^1.0.0",
 				"postcss": "^7.0.0",
 				"uniqs": "^2.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-value-parser": {
@@ -22375,6 +21569,12 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+			"dev": true
+		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -22387,9 +21587,9 @@
 			"integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
 		},
 		"pretty-bytes": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
-			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+			"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
 			"dev": true
 		},
 		"pretty-error": {
@@ -22647,6 +21847,16 @@
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+		},
+		"query-string": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+			"dev": true,
+			"requires": {
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
+			}
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -23277,32 +22487,39 @@
 			}
 		},
 		"react-app-polyfill": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.2.2.tgz",
-			"integrity": "sha512-mAYn96B/nB6kWG87Ry70F4D4rsycU43VYTj3ZCbKP+SLJXwC0x6YCbwcICh3uW8/C9s1VgP197yx+w7SCWeDdQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.4.tgz",
+			"integrity": "sha512-5Vte6ki7jpNsNCUKaboyofAhmURmCn2Y6Hu7ydJ6Iu4dct1CIGoh/1FT7gUZKAbowVX2lxVPlijvp1nKxfAl4w==",
 			"dev": true,
 			"requires": {
-				"core-js": "2.6.4",
+				"core-js": "3.2.1",
 				"object-assign": "4.1.1",
-				"promise": "8.0.2",
+				"promise": "8.0.3",
 				"raf": "3.4.1",
+				"regenerator-runtime": "0.13.3",
 				"whatwg-fetch": "3.0.0"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
-					"integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
 					"dev": true
 				},
 				"promise": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
-					"integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
+					"version": "8.0.3",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
+					"integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
 					"dev": true,
 					"requires": {
 						"asap": "~2.0.6"
 					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
 				}
 			}
 		},
@@ -23315,38 +22532,47 @@
 			}
 		},
 		"react-dev-utils": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-8.0.0.tgz",
-			"integrity": "sha512-TK8cj7eghvxfe7bfBluLGpI/upo4EXC+G74hYmPucAG8C2XcbT+vKnlWPwLnABb75Zk+mR6D556Da+yvDjljrw==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.1.0.tgz",
+			"integrity": "sha512-X2KYF/lIGyGwP/F/oXgGDF24nxDA2KC4b7AFto+eqzc/t838gpSGiaU8trTqHXOohuLxxc5qi1eDzsl9ucPDpg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0",
-				"address": "1.0.3",
-				"browserslist": "4.4.1",
+				"@babel/code-frame": "7.5.5",
+				"address": "1.1.2",
+				"browserslist": "4.7.0",
 				"chalk": "2.4.2",
 				"cross-spawn": "6.0.5",
 				"detect-port-alt": "1.1.6",
 				"escape-string-regexp": "1.0.5",
 				"filesize": "3.6.1",
 				"find-up": "3.0.0",
-				"fork-ts-checker-webpack-plugin": "1.0.0-alpha.6",
+				"fork-ts-checker-webpack-plugin": "1.5.0",
 				"global-modules": "2.0.0",
 				"globby": "8.0.2",
-				"gzip-size": "5.0.0",
+				"gzip-size": "5.1.1",
 				"immer": "1.10.0",
-				"inquirer": "6.2.1",
-				"is-root": "2.0.0",
+				"inquirer": "6.5.0",
+				"is-root": "2.1.0",
 				"loader-utils": "1.2.3",
-				"opn": "5.4.0",
+				"open": "^6.3.0",
 				"pkg-up": "2.0.0",
-				"react-error-overlay": "^5.1.4",
+				"react-error-overlay": "^6.0.3",
 				"recursive-readdir": "2.2.2",
-				"shell-quote": "1.6.1",
-				"sockjs-client": "1.3.0",
-				"strip-ansi": "5.0.0",
+				"shell-quote": "1.7.2",
+				"sockjs-client": "1.4.0",
+				"strip-ansi": "5.2.0",
 				"text-table": "0.2.0"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -23354,14 +22580,14 @@
 					"dev": true
 				},
 				"browserslist": {
-					"version": "4.4.1",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.1.tgz",
-					"integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
+					"version": "4.7.0",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+					"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30000929",
-						"electron-to-chromium": "^1.3.103",
-						"node-releases": "^1.1.3"
+						"caniuse-lite": "^1.0.30000989",
+						"electron-to-chromium": "^1.3.247",
+						"node-releases": "^1.1.29"
 					}
 				},
 				"find-up": {
@@ -23374,23 +22600,23 @@
 					}
 				},
 				"inquirer": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-					"integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+					"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
+						"ansi-escapes": "^3.2.0",
+						"chalk": "^2.4.2",
 						"cli-cursor": "^2.1.0",
 						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.0",
+						"external-editor": "^3.0.3",
 						"figures": "^2.0.0",
-						"lodash": "^4.17.10",
+						"lodash": "^4.17.12",
 						"mute-stream": "0.0.7",
 						"run-async": "^2.2.0",
-						"rxjs": "^6.1.0",
+						"rxjs": "^6.4.0",
 						"string-width": "^2.1.0",
-						"strip-ansi": "^5.0.0",
+						"strip-ansi": "^5.1.0",
 						"through": "^2.3.6"
 					}
 				},
@@ -23456,12 +22682,12 @@
 					}
 				},
 				"strip-ansi": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-					"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.0.0"
+						"ansi-regex": "^4.1.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -23527,9 +22753,9 @@
 			}
 		},
 		"react-error-overlay": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.6.tgz",
-			"integrity": "sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.3.tgz",
+			"integrity": "sha512-bOUvMWFQVk5oz8Ded9Xb7WVdEi3QGLC8tH7HmYP0Fdp4Bn3qw0tRFmr5TW6mvahzvmrK4a6bqWGfCevBflP+Xw==",
 			"dev": true
 		},
 		"react-fast-compare": {
@@ -23605,166 +22831,208 @@
 			}
 		},
 		"react-scripts": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-2.1.8.tgz",
-			"integrity": "sha512-mDC8fYWCyuB9VROti8OCPdHE79UEchVVZmuS/yaIs47VkvZpgZqUvzghYBswZRchqnW0aARNY8xXrzoFRhhK7A==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.2.0.tgz",
+			"integrity": "sha512-6LzuKbE2B4eFQG6i1FnTScn9HDcWBfXXnOwW9xKFPJ/E3rK8i1ufbOZ0ocKyRPxJAKdN7iqg3i7lt0+oxkSVOA==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "7.2.2",
-				"@svgr/webpack": "4.1.0",
-				"babel-core": "7.0.0-bridge.0",
-				"babel-eslint": "9.0.0",
-				"babel-jest": "23.6.0",
-				"babel-loader": "8.0.5",
-				"babel-plugin-named-asset-import": "^0.3.1",
-				"babel-preset-react-app": "^7.0.2",
-				"bfj": "6.1.1",
+				"@babel/core": "7.6.0",
+				"@svgr/webpack": "4.3.2",
+				"@typescript-eslint/eslint-plugin": "^2.2.0",
+				"@typescript-eslint/parser": "^2.2.0",
+				"babel-eslint": "10.0.3",
+				"babel-jest": "^24.9.0",
+				"babel-loader": "8.0.6",
+				"babel-plugin-named-asset-import": "^0.3.4",
+				"babel-preset-react-app": "^9.0.2",
+				"camelcase": "^5.2.0",
 				"case-sensitive-paths-webpack-plugin": "2.2.0",
-				"css-loader": "1.0.0",
-				"dotenv": "6.0.0",
-				"dotenv-expand": "4.2.0",
-				"eslint": "5.12.0",
-				"eslint-config-react-app": "^3.0.8",
-				"eslint-loader": "2.1.1",
-				"eslint-plugin-flowtype": "2.50.1",
-				"eslint-plugin-import": "2.14.0",
-				"eslint-plugin-jsx-a11y": "6.1.2",
-				"eslint-plugin-react": "7.12.4",
-				"file-loader": "2.0.0",
+				"css-loader": "2.1.1",
+				"dotenv": "6.2.0",
+				"dotenv-expand": "5.1.0",
+				"eslint": "^6.1.0",
+				"eslint-config-react-app": "^5.0.2",
+				"eslint-loader": "3.0.2",
+				"eslint-plugin-flowtype": "3.13.0",
+				"eslint-plugin-import": "2.18.2",
+				"eslint-plugin-jsx-a11y": "6.2.3",
+				"eslint-plugin-react": "7.14.3",
+				"eslint-plugin-react-hooks": "^1.6.1",
+				"file-loader": "3.0.1",
 				"fs-extra": "7.0.1",
-				"fsevents": "1.2.4",
-				"html-webpack-plugin": "4.0.0-alpha.2",
+				"fsevents": "2.0.7",
+				"html-webpack-plugin": "4.0.0-beta.5",
 				"identity-obj-proxy": "3.0.0",
-				"jest": "23.6.0",
-				"jest-pnp-resolver": "1.0.2",
-				"jest-resolve": "23.6.0",
-				"jest-watch-typeahead": "^0.2.1",
-				"mini-css-extract-plugin": "0.5.0",
-				"optimize-css-assets-webpack-plugin": "5.0.1",
-				"pnp-webpack-plugin": "1.2.1",
+				"is-wsl": "^1.1.0",
+				"jest": "24.9.0",
+				"jest-environment-jsdom-fourteen": "0.1.0",
+				"jest-resolve": "24.9.0",
+				"jest-watch-typeahead": "0.4.0",
+				"mini-css-extract-plugin": "0.8.0",
+				"optimize-css-assets-webpack-plugin": "5.0.3",
+				"pnp-webpack-plugin": "1.5.0",
 				"postcss-flexbugs-fixes": "4.1.0",
 				"postcss-loader": "3.0.0",
-				"postcss-preset-env": "6.5.0",
+				"postcss-normalize": "7.0.1",
+				"postcss-preset-env": "6.7.0",
 				"postcss-safe-parser": "4.0.1",
-				"react-app-polyfill": "^0.2.2",
-				"react-dev-utils": "^8.0.0",
-				"resolve": "1.10.0",
-				"sass-loader": "7.1.0",
-				"style-loader": "0.23.1",
-				"terser-webpack-plugin": "1.2.2",
-				"url-loader": "1.1.2",
-				"webpack": "4.28.3",
-				"webpack-dev-server": "3.1.14",
-				"webpack-manifest-plugin": "2.0.4",
-				"workbox-webpack-plugin": "3.6.3"
+				"react-app-polyfill": "^1.0.4",
+				"react-dev-utils": "^9.1.0",
+				"resolve": "1.12.0",
+				"resolve-url-loader": "3.1.0",
+				"sass-loader": "7.2.0",
+				"semver": "6.3.0",
+				"style-loader": "1.0.0",
+				"terser-webpack-plugin": "1.4.1",
+				"ts-pnp": "1.1.4",
+				"url-loader": "2.1.0",
+				"webpack": "4.41.0",
+				"webpack-dev-server": "3.2.1",
+				"webpack-manifest-plugin": "2.1.1",
+				"workbox-webpack-plugin": "4.3.1"
 			},
 			"dependencies": {
-				"@babel/core": {
-					"version": "7.2.2",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
-					"integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.2.2",
-						"@babel/helpers": "^7.2.0",
-						"@babel/parser": "^7.2.2",
-						"@babel/template": "^7.2.2",
-						"@babel/traverse": "^7.2.2",
-						"@babel/types": "^7.2.2",
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/core": {
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
+					"integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.6.0",
+						"@babel/helpers": "^7.6.0",
+						"@babel/parser": "^7.6.0",
+						"@babel/template": "^7.6.0",
+						"@babel/traverse": "^7.6.0",
+						"@babel/types": "^7.6.0",
 						"convert-source-map": "^1.1.0",
 						"debug": "^4.1.0",
 						"json5": "^2.1.0",
-						"lodash": "^4.17.10",
+						"lodash": "^4.17.13",
 						"resolve": "^1.3.2",
 						"semver": "^5.4.1",
 						"source-map": "^0.5.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+							"dev": true
+						}
 					}
 				},
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+				"@babel/generator": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+					"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.2",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+					"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.0",
+						"@babel/template": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+					"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+					"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
+					"integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.7.0",
+						"@babel/traverse": "^7.7.0",
+						"@babel/types": "^7.7.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+					"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
 					"dev": true
 				},
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+				"@babel/template": {
+					"version": "7.7.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+					"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.0",
+						"@babel/types": "^7.7.0"
 					}
 				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+				"@babel/traverse": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+					"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.2",
+						"@babel/helper-function-name": "^7.7.0",
+						"@babel/helper-split-export-declaration": "^7.7.0",
+						"@babel/parser": "^7.7.2",
+						"@babel/types": "^7.7.2",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+					"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
-				},
-				"babel-core": {
-					"version": "7.0.0-bridge.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-					"integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-					"dev": true
-				},
-				"babel-jest": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
-					"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
-					"dev": true,
-					"requires": {
-						"babel-plugin-istanbul": "^4.1.6",
-						"babel-preset-jest": "^23.2.0"
-					}
-				},
-				"babel-plugin-istanbul": {
-					"version": "4.1.6",
-					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-					"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
-					"dev": true,
-					"requires": {
-						"babel-plugin-syntax-object-rest-spread": "^6.13.0",
-						"find-up": "^2.1.0",
-						"istanbul-lib-instrument": "^1.10.1",
-						"test-exclude": "^4.2.1"
-					}
-				},
-				"babel-plugin-jest-hoist": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
-					"integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
-					"dev": true
-				},
-				"babel-preset-jest": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
-					"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
-					"dev": true,
-					"requires": {
-						"babel-plugin-jest-hoist": "^23.2.0",
-						"babel-plugin-syntax-object-rest-spread": "^6.13.0"
-					}
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"capture-exit": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
-					"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
-					"dev": true,
-					"requires": {
-						"rsvp": "^3.3.3"
-					}
 				},
 				"debug": {
 					"version": "4.1.1",
@@ -23775,1310 +23043,24 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"doctrine": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2"
-					}
-				},
 				"dotenv": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
-					"integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg==",
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+					"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
 					"dev": true
 				},
-				"eslint": {
-					"version": "5.12.0",
-					"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.0.tgz",
-					"integrity": "sha512-LntwyPxtOHrsJdcSwyQKVtHofPHdv+4+mFwEe91r2V13vqpM8yLr7b1sW+Oo/yheOPkWYsYlYJCkzlFAt8KV7g==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"ajv": "^6.5.3",
-						"chalk": "^2.1.0",
-						"cross-spawn": "^6.0.5",
-						"debug": "^4.0.1",
-						"doctrine": "^2.1.0",
-						"eslint-scope": "^4.0.0",
-						"eslint-utils": "^1.3.1",
-						"eslint-visitor-keys": "^1.0.0",
-						"espree": "^5.0.0",
-						"esquery": "^1.0.1",
-						"esutils": "^2.0.2",
-						"file-entry-cache": "^2.0.0",
-						"functional-red-black-tree": "^1.0.1",
-						"glob": "^7.1.2",
-						"globals": "^11.7.0",
-						"ignore": "^4.0.6",
-						"import-fresh": "^3.0.0",
-						"imurmurhash": "^0.1.4",
-						"inquirer": "^6.1.0",
-						"js-yaml": "^3.12.0",
-						"json-stable-stringify-without-jsonify": "^1.0.1",
-						"levn": "^0.3.0",
-						"lodash": "^4.17.5",
-						"minimatch": "^3.0.4",
-						"mkdirp": "^0.5.1",
-						"natural-compare": "^1.4.0",
-						"optionator": "^0.8.2",
-						"path-is-inside": "^1.0.2",
-						"pluralize": "^7.0.0",
-						"progress": "^2.0.0",
-						"regexpp": "^2.0.1",
-						"semver": "^5.5.1",
-						"strip-ansi": "^4.0.0",
-						"strip-json-comments": "^2.0.1",
-						"table": "^5.0.2",
-						"text-table": "^0.2.0"
-					}
-				},
-				"eslint-scope": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
-				},
-				"exec-sh": {
-					"version": "0.2.2",
-					"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-					"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
-					"dev": true,
-					"requires": {
-						"merge": "^1.2.0"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"expect": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
-					"integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"jest-diff": "^23.6.0",
-						"jest-get-type": "^22.1.0",
-						"jest-matcher-utils": "^23.6.0",
-						"jest-message-util": "^23.4.0",
-						"jest-regex-util": "^23.3.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
+				"eslint-plugin-react-hooks": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
+					"integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
+					"dev": true
 				},
 				"fsevents": {
-					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-					"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+					"version": "2.0.7",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
+					"integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"nan": "^2.9.2",
-						"node-pre-gyp": "^0.10.0"
-					},
-					"dependencies": {
-						"abbrev": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"ansi-regex": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"aproba": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"are-we-there-yet": {
-							"version": "1.1.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^2.0.6"
-							}
-						},
-						"balanced-match": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"brace-expansion": {
-							"version": "1.1.11",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"balanced-match": "^1.0.0",
-								"concat-map": "0.0.1"
-							}
-						},
-						"chownr": {
-							"version": "1.0.1",
-							"bundled": true
-						},
-						"code-point-at": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"concat-map": {
-							"version": "0.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"console-control-strings": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"core-util-is": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"debug": {
-							"version": "2.6.9",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"deep-extend": {
-							"version": "0.5.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"delegates": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"detect-libc": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"fs-minipass": {
-							"version": "1.2.5",
-							"bundled": true,
-							"requires": {
-								"minipass": "^2.2.1"
-							}
-						},
-						"fs.realpath": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"gauge": {
-							"version": "2.7.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"aproba": "^1.0.3",
-								"console-control-strings": "^1.0.0",
-								"has-unicode": "^2.0.0",
-								"object-assign": "^4.1.0",
-								"signal-exit": "^3.0.0",
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wide-align": "^1.1.0"
-							}
-						},
-						"glob": {
-							"version": "7.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						},
-						"has-unicode": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"iconv-lite": {
-							"version": "0.4.21",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safer-buffer": "^2.1.0"
-							}
-						},
-						"ignore-walk": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minimatch": "^3.0.4"
-							}
-						},
-						"inflight": {
-							"version": "1.0.6",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"once": "^1.3.0",
-								"wrappy": "1"
-							}
-						},
-						"inherits": {
-							"version": "2.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"ini": {
-							"version": "1.3.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
-						"isarray": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"minimatch": {
-							"version": "3.0.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"brace-expansion": "^1.1.7"
-							}
-						},
-						"minimist": {
-							"version": "0.0.8",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"minipass": {
-							"version": "2.2.4",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "^5.1.1",
-								"yallist": "^3.0.0"
-							}
-						},
-						"minizlib": {
-							"version": "1.1.0",
-							"bundled": true,
-							"requires": {
-								"minipass": "^2.2.1"
-							}
-						},
-						"mkdirp": {
-							"version": "0.5.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minimist": "0.0.8"
-							}
-						},
-						"ms": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"needle": {
-							"version": "2.2.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"debug": "^2.1.2",
-								"iconv-lite": "^0.4.4",
-								"sax": "^1.2.4"
-							}
-						},
-						"node-pre-gyp": {
-							"version": "0.10.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"detect-libc": "^1.0.2",
-								"mkdirp": "^0.5.1",
-								"needle": "^2.2.0",
-								"nopt": "^4.0.1",
-								"npm-packlist": "^1.1.6",
-								"npmlog": "^4.0.2",
-								"rc": "^1.1.7",
-								"rimraf": "^2.6.1",
-								"semver": "^5.3.0",
-								"tar": "^4"
-							}
-						},
-						"nopt": {
-							"version": "4.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"abbrev": "1",
-								"osenv": "^0.1.4"
-							}
-						},
-						"npm-bundled": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"npm-packlist": {
-							"version": "1.1.10",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ignore-walk": "^3.0.1",
-								"npm-bundled": "^1.0.1"
-							}
-						},
-						"npmlog": {
-							"version": "4.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"are-we-there-yet": "~1.1.2",
-								"console-control-strings": "~1.1.0",
-								"gauge": "~2.7.3",
-								"set-blocking": "~2.0.0"
-							}
-						},
-						"number-is-nan": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"object-assign": {
-							"version": "4.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"once": {
-							"version": "1.4.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"wrappy": "1"
-							}
-						},
-						"os-homedir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"os-tmpdir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"osenv": {
-							"version": "0.1.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"os-homedir": "^1.0.0",
-								"os-tmpdir": "^1.0.0"
-							}
-						},
-						"path-is-absolute": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"process-nextick-args": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"rc": {
-							"version": "1.2.7",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"deep-extend": "^0.5.1",
-								"ini": "~1.3.0",
-								"minimist": "^1.2.0",
-								"strip-json-comments": "~2.0.1"
-							},
-							"dependencies": {
-								"minimist": {
-									"version": "1.2.0",
-									"bundled": true,
-									"dev": true,
-									"optional": true
-								}
-							}
-						},
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"rimraf": {
-							"version": "2.6.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"glob": "^7.0.5"
-							}
-						},
-						"safe-buffer": {
-							"version": "5.1.1",
-							"bundled": true
-						},
-						"safer-buffer": {
-							"version": "2.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"sax": {
-							"version": "1.2.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"semver": {
-							"version": "5.5.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"set-blocking": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"signal-exit": {
-							"version": "3.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						},
-						"strip-json-comments": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"util-deprecate": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"wide-align": {
-							"version": "1.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"string-width": "^1.0.2"
-							}
-						},
-						"wrappy": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"yallist": {
-							"version": "3.0.2",
-							"bundled": true
-						}
-					}
-				},
-				"import-fresh": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-					"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
-					"dev": true,
-					"requires": {
-						"parent-module": "^1.0.0",
-						"resolve-from": "^4.0.0"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-							"dev": true
-						}
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-							"dev": true
-						}
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-							"dev": true
-						}
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"is-generator-fn": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-					"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"istanbul-lib-coverage": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-					"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
-					"dev": true
-				},
-				"istanbul-lib-instrument": {
-					"version": "1.10.2",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
-					"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
-					"dev": true,
-					"requires": {
-						"babel-generator": "^6.18.0",
-						"babel-template": "^6.16.0",
-						"babel-traverse": "^6.18.0",
-						"babel-types": "^6.18.0",
-						"babylon": "^6.18.0",
-						"istanbul-lib-coverage": "^1.2.1",
-						"semver": "^5.3.0"
-					}
-				},
-				"istanbul-lib-source-maps": {
-					"version": "1.2.6",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
-					"integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
-					"dev": true,
-					"requires": {
-						"debug": "^3.1.0",
-						"istanbul-lib-coverage": "^1.2.1",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.6.1",
-						"source-map": "^0.5.3"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "3.2.6",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-							"dev": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						}
-					}
-				},
-				"jest": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
-					"integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
-					"dev": true,
-					"requires": {
-						"import-local": "^1.0.0",
-						"jest-cli": "^23.6.0"
-					},
-					"dependencies": {
-						"jest-cli": {
-							"version": "23.6.0",
-							"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
-							"integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
-							"dev": true,
-							"requires": {
-								"ansi-escapes": "^3.0.0",
-								"chalk": "^2.0.1",
-								"exit": "^0.1.2",
-								"glob": "^7.1.2",
-								"graceful-fs": "^4.1.11",
-								"import-local": "^1.0.0",
-								"is-ci": "^1.0.10",
-								"istanbul-api": "^1.3.1",
-								"istanbul-lib-coverage": "^1.2.0",
-								"istanbul-lib-instrument": "^1.10.1",
-								"istanbul-lib-source-maps": "^1.2.4",
-								"jest-changed-files": "^23.4.2",
-								"jest-config": "^23.6.0",
-								"jest-environment-jsdom": "^23.4.0",
-								"jest-get-type": "^22.1.0",
-								"jest-haste-map": "^23.6.0",
-								"jest-message-util": "^23.4.0",
-								"jest-regex-util": "^23.3.0",
-								"jest-resolve-dependencies": "^23.6.0",
-								"jest-runner": "^23.6.0",
-								"jest-runtime": "^23.6.0",
-								"jest-snapshot": "^23.6.0",
-								"jest-util": "^23.4.0",
-								"jest-validate": "^23.6.0",
-								"jest-watcher": "^23.4.0",
-								"jest-worker": "^23.2.0",
-								"micromatch": "^2.3.11",
-								"node-notifier": "^5.2.1",
-								"prompts": "^0.1.9",
-								"realpath-native": "^1.0.0",
-								"rimraf": "^2.5.4",
-								"slash": "^1.0.0",
-								"string-length": "^2.0.0",
-								"strip-ansi": "^4.0.0",
-								"which": "^1.2.12",
-								"yargs": "^11.0.0"
-							}
-						}
-					}
-				},
-				"jest-changed-files": {
-					"version": "23.4.2",
-					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
-					"integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
-					"dev": true,
-					"requires": {
-						"throat": "^4.0.0"
-					}
-				},
-				"jest-config": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
-					"integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
-					"dev": true,
-					"requires": {
-						"babel-core": "^6.0.0",
-						"babel-jest": "^23.6.0",
-						"chalk": "^2.0.1",
-						"glob": "^7.1.1",
-						"jest-environment-jsdom": "^23.4.0",
-						"jest-environment-node": "^23.4.0",
-						"jest-get-type": "^22.1.0",
-						"jest-jasmine2": "^23.6.0",
-						"jest-regex-util": "^23.3.0",
-						"jest-resolve": "^23.6.0",
-						"jest-util": "^23.4.0",
-						"jest-validate": "^23.6.0",
-						"micromatch": "^2.3.11",
-						"pretty-format": "^23.6.0"
-					},
-					"dependencies": {
-						"babel-core": {
-							"version": "6.26.3",
-							"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-							"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-							"dev": true,
-							"requires": {
-								"babel-code-frame": "^6.26.0",
-								"babel-generator": "^6.26.0",
-								"babel-helpers": "^6.24.1",
-								"babel-messages": "^6.23.0",
-								"babel-register": "^6.26.0",
-								"babel-runtime": "^6.26.0",
-								"babel-template": "^6.26.0",
-								"babel-traverse": "^6.26.0",
-								"babel-types": "^6.26.0",
-								"babylon": "^6.18.0",
-								"convert-source-map": "^1.5.1",
-								"debug": "^2.6.9",
-								"json5": "^0.5.1",
-								"lodash": "^4.17.4",
-								"minimatch": "^3.0.4",
-								"path-is-absolute": "^1.0.1",
-								"private": "^0.1.8",
-								"slash": "^1.0.0",
-								"source-map": "^0.5.7"
-							}
-						},
-						"debug": {
-							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"json5": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-							"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-							"dev": true
-						},
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						}
-					}
-				},
-				"jest-diff": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
-					"integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.1",
-						"diff": "^3.2.0",
-						"jest-get-type": "^22.1.0",
-						"pretty-format": "^23.6.0"
-					}
-				},
-				"jest-docblock": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
-					"integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
-					"dev": true,
-					"requires": {
-						"detect-newline": "^2.1.0"
-					}
-				},
-				"jest-each": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
-					"integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.1",
-						"pretty-format": "^23.6.0"
-					}
-				},
-				"jest-environment-jsdom": {
-					"version": "23.4.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
-					"integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
-					"dev": true,
-					"requires": {
-						"jest-mock": "^23.2.0",
-						"jest-util": "^23.4.0",
-						"jsdom": "^11.5.1"
-					}
-				},
-				"jest-environment-node": {
-					"version": "23.4.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
-					"integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
-					"dev": true,
-					"requires": {
-						"jest-mock": "^23.2.0",
-						"jest-util": "^23.4.0"
-					}
-				},
-				"jest-get-type": {
-					"version": "22.4.3",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-					"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
-					"dev": true
-				},
-				"jest-haste-map": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
-					"integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
-					"dev": true,
-					"requires": {
-						"fb-watchman": "^2.0.0",
-						"graceful-fs": "^4.1.11",
-						"invariant": "^2.2.4",
-						"jest-docblock": "^23.2.0",
-						"jest-serializer": "^23.0.1",
-						"jest-worker": "^23.2.0",
-						"micromatch": "^2.3.11",
-						"sane": "^2.0.0"
-					}
-				},
-				"jest-jasmine2": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
-					"integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
-					"dev": true,
-					"requires": {
-						"babel-traverse": "^6.0.0",
-						"chalk": "^2.0.1",
-						"co": "^4.6.0",
-						"expect": "^23.6.0",
-						"is-generator-fn": "^1.0.0",
-						"jest-diff": "^23.6.0",
-						"jest-each": "^23.6.0",
-						"jest-matcher-utils": "^23.6.0",
-						"jest-message-util": "^23.4.0",
-						"jest-snapshot": "^23.6.0",
-						"jest-util": "^23.4.0",
-						"pretty-format": "^23.6.0"
-					}
-				},
-				"jest-leak-detector": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
-					"integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
-					"dev": true,
-					"requires": {
-						"pretty-format": "^23.6.0"
-					}
-				},
-				"jest-matcher-utils": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
-					"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.1",
-						"jest-get-type": "^22.1.0",
-						"pretty-format": "^23.6.0"
-					}
-				},
-				"jest-message-util": {
-					"version": "23.4.0",
-					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
-					"integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0-beta.35",
-						"chalk": "^2.0.1",
-						"micromatch": "^2.3.11",
-						"slash": "^1.0.0",
-						"stack-utils": "^1.0.1"
-					}
-				},
-				"jest-mock": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
-					"integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=",
-					"dev": true
-				},
-				"jest-pnp-resolver": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.0.2.tgz",
-					"integrity": "sha512-H2DvUlwdMedNGv4FOliPDnxani6ATWy70xe2eckGJgkLoMaWzRPqpSlc5ShqX0Ltk5OhRQvPQY2LLZPOpgcc7g==",
-					"dev": true
-				},
-				"jest-regex-util": {
-					"version": "23.3.0",
-					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
-					"integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U=",
-					"dev": true
-				},
-				"jest-resolve": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
-					"integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
-					"dev": true,
-					"requires": {
-						"browser-resolve": "^1.11.3",
-						"chalk": "^2.0.1",
-						"realpath-native": "^1.0.0"
-					}
-				},
-				"jest-resolve-dependencies": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
-					"integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
-					"dev": true,
-					"requires": {
-						"jest-regex-util": "^23.3.0",
-						"jest-snapshot": "^23.6.0"
-					}
-				},
-				"jest-runner": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
-					"integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
-					"dev": true,
-					"requires": {
-						"exit": "^0.1.2",
-						"graceful-fs": "^4.1.11",
-						"jest-config": "^23.6.0",
-						"jest-docblock": "^23.2.0",
-						"jest-haste-map": "^23.6.0",
-						"jest-jasmine2": "^23.6.0",
-						"jest-leak-detector": "^23.6.0",
-						"jest-message-util": "^23.4.0",
-						"jest-runtime": "^23.6.0",
-						"jest-util": "^23.4.0",
-						"jest-worker": "^23.2.0",
-						"source-map-support": "^0.5.6",
-						"throat": "^4.0.0"
-					}
-				},
-				"jest-runtime": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
-					"integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
-					"dev": true,
-					"requires": {
-						"babel-core": "^6.0.0",
-						"babel-plugin-istanbul": "^4.1.6",
-						"chalk": "^2.0.1",
-						"convert-source-map": "^1.4.0",
-						"exit": "^0.1.2",
-						"fast-json-stable-stringify": "^2.0.0",
-						"graceful-fs": "^4.1.11",
-						"jest-config": "^23.6.0",
-						"jest-haste-map": "^23.6.0",
-						"jest-message-util": "^23.4.0",
-						"jest-regex-util": "^23.3.0",
-						"jest-resolve": "^23.6.0",
-						"jest-snapshot": "^23.6.0",
-						"jest-util": "^23.4.0",
-						"jest-validate": "^23.6.0",
-						"micromatch": "^2.3.11",
-						"realpath-native": "^1.0.0",
-						"slash": "^1.0.0",
-						"strip-bom": "3.0.0",
-						"write-file-atomic": "^2.1.0",
-						"yargs": "^11.0.0"
-					},
-					"dependencies": {
-						"babel-core": {
-							"version": "6.26.3",
-							"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-							"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-							"dev": true,
-							"requires": {
-								"babel-code-frame": "^6.26.0",
-								"babel-generator": "^6.26.0",
-								"babel-helpers": "^6.24.1",
-								"babel-messages": "^6.23.0",
-								"babel-register": "^6.26.0",
-								"babel-runtime": "^6.26.0",
-								"babel-template": "^6.26.0",
-								"babel-traverse": "^6.26.0",
-								"babel-types": "^6.26.0",
-								"babylon": "^6.18.0",
-								"convert-source-map": "^1.5.1",
-								"debug": "^2.6.9",
-								"json5": "^0.5.1",
-								"lodash": "^4.17.4",
-								"minimatch": "^3.0.4",
-								"path-is-absolute": "^1.0.1",
-								"private": "^0.1.8",
-								"slash": "^1.0.0",
-								"source-map": "^0.5.7"
-							}
-						},
-						"debug": {
-							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"json5": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-							"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-							"dev": true
-						},
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						},
-						"strip-bom": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-							"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-							"dev": true
-						}
-					}
-				},
-				"jest-serializer": {
-					"version": "23.0.1",
-					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-					"integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
-					"dev": true
-				},
-				"jest-snapshot": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
-					"integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
-					"dev": true,
-					"requires": {
-						"babel-types": "^6.0.0",
-						"chalk": "^2.0.1",
-						"jest-diff": "^23.6.0",
-						"jest-matcher-utils": "^23.6.0",
-						"jest-message-util": "^23.4.0",
-						"jest-resolve": "^23.6.0",
-						"mkdirp": "^0.5.1",
-						"natural-compare": "^1.4.0",
-						"pretty-format": "^23.6.0",
-						"semver": "^5.5.0"
-					}
-				},
-				"jest-util": {
-					"version": "23.4.0",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
-					"integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
-					"dev": true,
-					"requires": {
-						"callsites": "^2.0.0",
-						"chalk": "^2.0.1",
-						"graceful-fs": "^4.1.11",
-						"is-ci": "^1.0.10",
-						"jest-message-util": "^23.4.0",
-						"mkdirp": "^0.5.1",
-						"slash": "^1.0.0",
-						"source-map": "^0.6.0"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.6.1",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-							"dev": true
-						}
-					}
-				},
-				"jest-validate": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
-					"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.1",
-						"jest-get-type": "^22.1.0",
-						"leven": "^2.1.0",
-						"pretty-format": "^23.6.0"
-					}
-				},
-				"jest-watcher": {
-					"version": "23.4.0",
-					"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
-					"integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
-					"dev": true,
-					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.1",
-						"string-length": "^2.0.0"
-					}
-				},
-				"jest-worker": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
-					"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
-					"dev": true,
-					"requires": {
-						"merge-stream": "^1.0.1"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"kleur": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
-					"integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==",
-					"dev": true
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
-					}
+					"optional": true
 				},
 				"ms": {
 					"version": "2.1.2",
@@ -25086,421 +23068,20 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+				"resolve": {
+					"version": "1.12.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+					"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"path-parse": "^1.0.6"
 					}
 				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
-				},
-				"pretty-format": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0",
-						"ansi-styles": "^3.2.0"
-					}
-				},
-				"prompts": {
-					"version": "0.1.14",
-					"resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
-					"integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
-					"dev": true,
-					"requires": {
-						"kleur": "^2.0.1",
-						"sisteransi": "^0.1.1"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "1.1.2",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-							"dev": true,
-							"requires": {
-								"path-exists": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
-							}
-						}
-					}
-				},
-				"rsvp": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-					"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-					"dev": true
-				},
-				"sane": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
-					"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
-					"dev": true,
-					"requires": {
-						"anymatch": "^2.0.0",
-						"capture-exit": "^1.2.0",
-						"exec-sh": "^0.2.0",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^1.2.3",
-						"micromatch": "^3.1.4",
-						"minimist": "^1.1.1",
-						"walker": "~1.0.5",
-						"watch": "~0.18.0"
-					},
-					"dependencies": {
-						"arr-diff": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-							"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-							"dev": true
-						},
-						"array-unique": {
-							"version": "0.3.2",
-							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-							"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-							"dev": true
-						},
-						"braces": {
-							"version": "2.3.2",
-							"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-							"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-							"dev": true,
-							"requires": {
-								"arr-flatten": "^1.1.0",
-								"array-unique": "^0.3.2",
-								"extend-shallow": "^2.0.1",
-								"fill-range": "^4.0.0",
-								"isobject": "^3.0.1",
-								"repeat-element": "^1.1.2",
-								"snapdragon": "^0.8.1",
-								"snapdragon-node": "^2.0.1",
-								"split-string": "^3.0.2",
-								"to-regex": "^3.0.1"
-							},
-							"dependencies": {
-								"extend-shallow": {
-									"version": "2.0.1",
-									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-									"dev": true,
-									"requires": {
-										"is-extendable": "^0.1.0"
-									}
-								}
-							}
-						},
-						"debug": {
-							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"expand-brackets": {
-							"version": "2.1.4",
-							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-							"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-							"dev": true,
-							"requires": {
-								"debug": "^2.3.3",
-								"define-property": "^0.2.5",
-								"extend-shallow": "^2.0.1",
-								"posix-character-classes": "^0.1.0",
-								"regex-not": "^1.0.0",
-								"snapdragon": "^0.8.1",
-								"to-regex": "^3.0.1"
-							},
-							"dependencies": {
-								"define-property": {
-									"version": "0.2.5",
-									"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-									"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-									"dev": true,
-									"requires": {
-										"is-descriptor": "^0.1.0"
-									}
-								},
-								"extend-shallow": {
-									"version": "2.0.1",
-									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-									"dev": true,
-									"requires": {
-										"is-extendable": "^0.1.0"
-									}
-								},
-								"is-descriptor": {
-									"version": "0.1.6",
-									"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-									"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-									"dev": true,
-									"requires": {
-										"is-accessor-descriptor": "^0.1.6",
-										"is-data-descriptor": "^0.1.4",
-										"kind-of": "^5.0.0"
-									}
-								},
-								"kind-of": {
-									"version": "5.1.0",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-									"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-									"dev": true
-								}
-							}
-						},
-						"extglob": {
-							"version": "2.0.4",
-							"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-							"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-							"dev": true,
-							"requires": {
-								"array-unique": "^0.3.2",
-								"define-property": "^1.0.0",
-								"expand-brackets": "^2.1.4",
-								"extend-shallow": "^2.0.1",
-								"fragment-cache": "^0.2.1",
-								"regex-not": "^1.0.0",
-								"snapdragon": "^0.8.1",
-								"to-regex": "^3.0.1"
-							},
-							"dependencies": {
-								"define-property": {
-									"version": "1.0.0",
-									"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-									"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-									"dev": true,
-									"requires": {
-										"is-descriptor": "^1.0.0"
-									}
-								},
-								"extend-shallow": {
-									"version": "2.0.1",
-									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-									"dev": true,
-									"requires": {
-										"is-extendable": "^0.1.0"
-									}
-								}
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-							"dev": true
-						},
-						"micromatch": {
-							"version": "3.1.10",
-							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-							"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-							"dev": true,
-							"requires": {
-								"arr-diff": "^4.0.0",
-								"array-unique": "^0.3.2",
-								"braces": "^2.3.1",
-								"define-property": "^2.0.2",
-								"extend-shallow": "^3.0.2",
-								"extglob": "^2.0.4",
-								"fragment-cache": "^0.2.1",
-								"kind-of": "^6.0.2",
-								"nanomatch": "^1.2.9",
-								"object.pick": "^1.3.0",
-								"regex-not": "^1.0.0",
-								"snapdragon": "^0.8.1",
-								"to-regex": "^3.0.2"
-							}
-						},
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						}
-					}
-				},
-				"sisteransi": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
-					"integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"test-exclude": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
-					"integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
-					"dev": true,
-					"requires": {
-						"arrify": "^1.0.1",
-						"micromatch": "^2.3.11",
-						"object-assign": "^4.1.0",
-						"read-pkg-up": "^1.0.1",
-						"require-main-filename": "^1.0.1"
-					}
-				},
-				"watch": {
-					"version": "0.18.0",
-					"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
-					"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-					"dev": true,
-					"requires": {
-						"exec-sh": "^0.2.0",
-						"minimist": "^1.2.0"
-					}
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-					"dev": true
-				},
-				"yargs": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.1.tgz",
-					"integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.1.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "9.0.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
 				}
 			}
 		},
@@ -25800,6 +23381,12 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regex-parser": {
+			"version": "2.2.10",
+			"resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.10.tgz",
+			"integrity": "sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA==",
+			"dev": true
+		},
 		"regexp.prototype.flags": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
@@ -25888,6 +23475,12 @@
 						"domutils": "1.5.1",
 						"nth-check": "~1.0.1"
 					}
+				},
+				"css-what": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+					"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+					"dev": true
 				},
 				"domutils": {
 					"version": "1.5.1",
@@ -26041,6 +23634,58 @@
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
 		},
+		"resolve-url-loader": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.0.tgz",
+			"integrity": "sha512-2QcrA+2QgVqsMJ1Hn5NnJXIGCX1clQ1F6QJTqOeiaDw9ACo1G2k+8/shq3mtqne03HOFyskAClqfxKyFBriXZg==",
+			"dev": true,
+			"requires": {
+				"adjust-sourcemap-loader": "2.0.0",
+				"camelcase": "5.0.0",
+				"compose-function": "3.0.3",
+				"convert-source-map": "1.6.0",
+				"es6-iterator": "2.0.3",
+				"loader-utils": "1.2.3",
+				"postcss": "7.0.14",
+				"rework": "1.0.1",
+				"rework-visit": "1.0.0",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.14",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -26061,6 +23706,30 @@
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
 			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+			"dev": true
+		},
+		"rework": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
+			"integrity": "sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=",
+			"dev": true,
+			"requires": {
+				"convert-source-map": "^0.3.3",
+				"css": "^2.0.0"
+			},
+			"dependencies": {
+				"convert-source-map": {
+					"version": "0.3.5",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+					"integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
+					"dev": true
+				}
+			}
+		},
+		"rework-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz",
+			"integrity": "sha1-mUWygD8hni96ygCtuLyfZA+ELJo=",
 			"dev": true
 		},
 		"rgb-regex": {
@@ -26172,57 +23841,42 @@
 			}
 		},
 		"sass-loader": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.1.0.tgz",
-			"integrity": "sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.2.0.tgz",
+			"integrity": "sha512-h8yUWaWtsbuIiOCgR9fd9c2lRXZ2uG+h8Dzg/AGNj+Hg/3TO8+BBAW9mEP+mh8ei+qBKqSJ0F1FLlYjNBc61OA==",
 			"dev": true,
 			"requires": {
-				"clone-deep": "^2.0.1",
+				"clone-deep": "^4.0.1",
 				"loader-utils": "^1.0.1",
-				"lodash.tail": "^4.1.1",
 				"neo-async": "^2.5.0",
-				"pify": "^3.0.0",
+				"pify": "^4.0.1",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
 				"clone-deep": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
-					"integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+					"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
 					"dev": true,
 					"requires": {
-						"for-own": "^1.0.0",
 						"is-plain-object": "^2.0.4",
-						"kind-of": "^6.0.0",
-						"shallow-clone": "^1.0.0"
+						"kind-of": "^6.0.2",
+						"shallow-clone": "^3.0.0"
 					}
 				},
-				"for-own": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.1"
-					}
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
 				},
 				"shallow-clone": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
-					"integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+					"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.1",
-						"kind-of": "^5.0.0",
-						"mixin-object": "^2.0.1"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
+						"kind-of": "^6.0.2"
 					}
 				}
 			}
@@ -26231,6 +23885,15 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
+		"saxes": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+			"dev": true,
+			"requires": {
+				"xmlchars": "^2.1.1"
+			}
 		},
 		"scheduler": {
 			"version": "0.17.0",
@@ -26468,16 +24131,10 @@
 			"dev": true
 		},
 		"shell-quote": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-			"dev": true,
-			"requires": {
-				"array-filter": "~0.0.0",
-				"array-map": "~0.0.0",
-				"array-reduce": "~0.0.0",
-				"jsonify": "~0.0.0"
-			}
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+			"dev": true
 		},
 		"shelljs": {
 			"version": "0.7.7",
@@ -26723,9 +24380,9 @@
 			}
 		},
 		"sockjs-client": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
-			"integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
+			"integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.2.5",
@@ -27109,6 +24766,12 @@
 			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
 			"integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
 		},
+		"strict-uri-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+			"dev": true
+		},
 		"string-argv": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.1.2.tgz",
@@ -27249,13 +24912,37 @@
 			}
 		},
 		"style-loader": {
-			"version": "0.23.1",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
-			"integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.0.0.tgz",
+			"integrity": "sha512-B0dOCFwv7/eY31a5PCieNwMgMhVGFe9w+rh7s/Bx8kfFkrth9zfTZquoYvdw8URgiqxObQKcpW51Ugz1HjfdZw==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.1.0",
-				"schema-utils": "^1.0.0"
+				"loader-utils": "^1.2.3",
+				"schema-utils": "^2.0.1"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"schema-utils": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.5.0.tgz",
+					"integrity": "sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
+					}
+				}
 			}
 		},
 		"styled-components": {
@@ -27289,17 +24976,6 @@
 				"postcss-selector-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.21",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-					"integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"postcss-selector-parser": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -27309,21 +24985,6 @@
 						"dot-prop": "^4.1.1",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -27429,17 +25090,17 @@
 			"dev": true
 		},
 		"svgo": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
-			"integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+			"integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
 				"coa": "^2.0.2",
 				"css-select": "^2.0.0",
 				"css-select-base-adapter": "^0.1.1",
-				"css-tree": "1.0.0-alpha.33",
-				"csso": "^3.5.1",
+				"css-tree": "1.0.0-alpha.37",
+				"csso": "^4.0.2",
 				"js-yaml": "^3.13.1",
 				"mkdirp": "~0.5.1",
 				"object.values": "^1.1.0",
@@ -27620,14 +25281,14 @@
 			}
 		},
 		"terser": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.4.0.tgz",
+			"integrity": "sha512-oDG16n2WKm27JO8h4y/w3iqBGAOSCtq7k8dRmrn4Wf9NouL0b2WpMHGChFGZq4nFAQy1FsNJrVQHfurXOSTmOA==",
 			"dev": true,
 			"requires": {
-				"commander": "^2.19.0",
+				"commander": "^2.20.0",
 				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.10"
+				"source-map-support": "~0.5.12"
 			},
 			"dependencies": {
 				"commander": {
@@ -27645,19 +25306,20 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.2.tgz",
-			"integrity": "sha512-1DMkTk286BzmfylAvLXwpJrI7dWa5BnFmscV/2dCr8+c56egFcbaeFAl7+sujAjdmpLam21XRdhA4oifLyiWWg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
+			"integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
 			"dev": true,
 			"requires": {
-				"cacache": "^11.0.2",
-				"find-cache-dir": "^2.0.0",
+				"cacache": "^12.0.2",
+				"find-cache-dir": "^2.1.0",
+				"is-wsl": "^1.1.0",
 				"schema-utils": "^1.0.0",
-				"serialize-javascript": "^1.4.0",
+				"serialize-javascript": "^1.7.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.16.1",
-				"webpack-sources": "^1.1.0",
-				"worker-farm": "^1.5.2"
+				"terser": "^4.1.2",
+				"webpack-sources": "^1.4.0",
+				"worker-farm": "^1.7.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -27895,15 +25557,6 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
-		"topo": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-			"integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-			"dev": true,
-			"requires": {
-				"hoek": "4.x.x"
-			}
-		},
 		"tough-cookie": {
 			"version": "2.4.3",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -27962,12 +25615,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
 			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
-			"dev": true
-		},
-		"tryer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
 			"dev": true
 		},
 		"ts-invariant": {
@@ -28247,6 +25894,12 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+		},
+		"type": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -28602,14 +26255,38 @@
 			}
 		},
 		"url-loader": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
-			"integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-2.1.0.tgz",
+			"integrity": "sha512-kVrp/8VfEm5fUt+fl2E0FQyrpmOYgMEkBsv8+UDP1wFhszECq5JyGF33I7cajlVY90zRZ6MyfgKXngLvHYZX8A==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.1.0",
-				"mime": "^2.0.3",
-				"schema-utils": "^1.0.0"
+				"loader-utils": "^1.2.3",
+				"mime": "^2.4.4",
+				"schema-utils": "^2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"schema-utils": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.5.0.tgz",
+					"integrity": "sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
+					}
+				}
 			}
 		},
 		"url-parse": {
@@ -28662,12 +26339,20 @@
 			}
 		},
 		"util": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
-			"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "2.0.1"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+					"dev": true
+				}
 			}
 		},
 		"util-deprecate": {
@@ -28766,9 +26451,9 @@
 			}
 		},
 		"vm-browserify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
-			"integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
 			"dev": true
 		},
 		"vscode-jsonrpc": {
@@ -28816,6 +26501,17 @@
 			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "^0.1.2"
+			}
+		},
+		"w3c-xmlserializer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+			"integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+			"dev": true,
+			"requires": {
+				"domexception": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"xml-name-validator": "^3.0.0"
 			}
 		},
 		"walker": {
@@ -28871,75 +26567,73 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "4.28.3",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.28.3.tgz",
-			"integrity": "sha512-vLZN9k5I7Nr/XB1IDG9GbZB4yQd1sPuvufMFgJkx0b31fi2LD97KQIjwjxE7xytdruAYfu5S0FLBLjdxmwGJCg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.0.tgz",
+			"integrity": "sha512-yNV98U4r7wX1VJAj5kyMsu36T8RPPQntcb5fJLOsMz/pt/WrKC0Vp1bAlqPLkA1LegSwQwf6P+kAbyhRKVQ72g==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-module-context": "1.7.11",
-				"@webassemblyjs/wasm-edit": "1.7.11",
-				"@webassemblyjs/wasm-parser": "1.7.11",
-				"acorn": "^5.6.2",
-				"acorn-dynamic-import": "^3.0.0",
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0",
-				"chrome-trace-event": "^1.0.0",
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-module-context": "1.8.5",
+				"@webassemblyjs/wasm-edit": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5",
+				"acorn": "^6.2.1",
+				"ajv": "^6.10.2",
+				"ajv-keywords": "^3.4.1",
+				"chrome-trace-event": "^1.0.2",
 				"enhanced-resolve": "^4.1.0",
-				"eslint-scope": "^4.0.0",
+				"eslint-scope": "^4.0.3",
 				"json-parse-better-errors": "^1.0.2",
-				"loader-runner": "^2.3.0",
-				"loader-utils": "^1.1.0",
-				"memory-fs": "~0.4.1",
-				"micromatch": "^3.1.8",
-				"mkdirp": "~0.5.0",
-				"neo-async": "^2.5.0",
-				"node-libs-browser": "^2.0.0",
-				"schema-utils": "^0.4.4",
-				"tapable": "^1.1.0",
-				"terser-webpack-plugin": "^1.1.0",
-				"watchpack": "^1.5.0",
-				"webpack-sources": "^1.3.0"
+				"loader-runner": "^2.4.0",
+				"loader-utils": "^1.2.3",
+				"memory-fs": "^0.4.1",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.1",
+				"neo-async": "^2.6.1",
+				"node-libs-browser": "^2.2.1",
+				"schema-utils": "^1.0.0",
+				"tapable": "^1.1.3",
+				"terser-webpack-plugin": "^1.4.1",
+				"watchpack": "^1.6.0",
+				"webpack-sources": "^1.4.1"
 			},
 			"dependencies": {
-				"eslint-scope": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
+				"acorn": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+					"dev": true
 				},
-				"schema-utils": {
-					"version": "0.4.7",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+				"ajv": {
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
 					}
 				}
 			}
 		},
 		"webpack-dev-middleware": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
-			"integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+			"integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
 			"dev": true,
 			"requires": {
-				"memory-fs": "~0.4.1",
-				"mime": "^2.3.1",
-				"range-parser": "^1.0.3",
+				"memory-fs": "^0.4.1",
+				"mime": "^2.4.4",
+				"mkdirp": "^0.5.1",
+				"range-parser": "^1.2.1",
 				"webpack-log": "^2.0.0"
 			}
 		},
 		"webpack-dev-server": {
-			"version": "3.1.14",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
-			"integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.2.1.tgz",
+			"integrity": "sha512-sjuE4mnmx6JOh9kvSbPYw3u/6uxCLHNWfhWaIPwcXWsvWOPN+nc5baq4i9jui3oOBRXGonK9+OI0jVkaz6/rCw==",
 			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
@@ -28947,13 +26641,13 @@
 				"chokidar": "^2.0.0",
 				"compression": "^1.5.2",
 				"connect-history-api-fallback": "^1.3.0",
-				"debug": "^3.1.0",
+				"debug": "^4.1.1",
 				"del": "^3.0.0",
 				"express": "^4.16.2",
 				"html-entities": "^1.2.0",
-				"http-proxy-middleware": "~0.18.0",
+				"http-proxy-middleware": "^0.19.1",
 				"import-local": "^2.0.0",
-				"internal-ip": "^3.0.1",
+				"internal-ip": "^4.2.0",
 				"ip": "^1.1.5",
 				"killable": "^1.0.0",
 				"loglevel": "^1.4.1",
@@ -28967,9 +26661,9 @@
 				"sockjs-client": "1.3.0",
 				"spdy": "^4.0.0",
 				"strip-ansi": "^3.0.0",
-				"supports-color": "^5.1.0",
+				"supports-color": "^6.1.0",
 				"url": "^0.11.0",
-				"webpack-dev-middleware": "3.4.0",
+				"webpack-dev-middleware": "^3.5.1",
 				"webpack-log": "^2.0.0",
 				"yargs": "12.0.2"
 			},
@@ -28981,9 +26675,9 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -29005,16 +26699,6 @@
 					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
-					}
-				},
-				"import-local": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-					"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-					"dev": true,
-					"requires": {
-						"pkg-dir": "^3.0.0",
-						"resolve-cwd": "^2.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -29069,6 +26753,31 @@
 					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
 					"dev": true
 				},
+				"sockjs-client": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
+					"integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
+					"dev": true,
+					"requires": {
+						"debug": "^3.2.5",
+						"eventsource": "^1.0.7",
+						"faye-websocket": "~0.11.1",
+						"inherits": "^2.0.3",
+						"json3": "^3.3.2",
+						"url-parse": "^1.4.3"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.2.6",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+							"dev": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						}
+					}
+				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -29088,6 +26797,15 @@
 								"ansi-regex": "^3.0.0"
 							}
 						}
+					}
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				},
 				"url": {
@@ -29142,13 +26860,14 @@
 			}
 		},
 		"webpack-manifest-plugin": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz",
-			"integrity": "sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.1.1.tgz",
+			"integrity": "sha512-2zqJ6mvc3yoiqfDjghAIpljhLSDh/G7vqGrzYcYqqRCd/ZZZCAuc/YPE5xG0LGpLgDJRhUNV1H+znyyhIxahzA==",
 			"dev": true,
 			"requires": {
 				"fs-extra": "^7.0.0",
 				"lodash": ">=3.5 <5",
+				"object.entries": "^1.1.0",
 				"tapable": "^1.0.0"
 			}
 		},
@@ -29339,51 +27058,52 @@
 			"dev": true
 		},
 		"workbox-background-sync": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.6.3.tgz",
-			"integrity": "sha512-ypLo0B6dces4gSpaslmDg5wuoUWrHHVJfFWwl1udvSylLdXvnrfhFfriCS42SNEe5lsZtcNZF27W/SMzBlva7Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-4.3.1.tgz",
+			"integrity": "sha512-1uFkvU8JXi7L7fCHVBEEnc3asPpiAL33kO495UMcD5+arew9IbKW2rV5lpzhoWcm/qhGB89YfO4PmB/0hQwPRg==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
-		"workbox-broadcast-cache-update": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.6.3.tgz",
-			"integrity": "sha512-pJl4lbClQcvp0SyTiEw0zLSsVYE1RDlCPtpKnpMjxFtu8lCFTAEuVyzxp9w7GF4/b3P4h5nyQ+q7V9mIR7YzGg==",
+		"workbox-broadcast-update": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-4.3.1.tgz",
+			"integrity": "sha512-MTSfgzIljpKLTBPROo4IpKjESD86pPFlZwlvVG32Kb70hW+aob4Jxpblud8EhNb1/L5m43DUM4q7C+W6eQMMbA==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-build": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.6.3.tgz",
-			"integrity": "sha512-w0clZ/pVjL8VXy6GfthefxpEXs0T8uiRuopZSFVQ8ovfbH6c6kUpEh6DcYwm/Y6dyWPiCucdyAZotgjz+nRz8g==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-4.3.1.tgz",
+			"integrity": "sha512-UHdwrN3FrDvicM3AqJS/J07X0KXj67R8Cg0waq1MKEOqzo89ap6zh6LmaLnRAjpB+bDIz+7OlPye9iii9KBnxw==",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"common-tags": "^1.4.0",
+				"@babel/runtime": "^7.3.4",
+				"@hapi/joi": "^15.0.0",
+				"common-tags": "^1.8.0",
 				"fs-extra": "^4.0.2",
-				"glob": "^7.1.2",
-				"joi": "^11.1.1",
+				"glob": "^7.1.3",
 				"lodash.template": "^4.4.0",
-				"pretty-bytes": "^4.0.2",
-				"stringify-object": "^3.2.2",
+				"pretty-bytes": "^5.1.0",
+				"stringify-object": "^3.3.0",
 				"strip-comments": "^1.0.2",
-				"workbox-background-sync": "^3.6.3",
-				"workbox-broadcast-cache-update": "^3.6.3",
-				"workbox-cache-expiration": "^3.6.3",
-				"workbox-cacheable-response": "^3.6.3",
-				"workbox-core": "^3.6.3",
-				"workbox-google-analytics": "^3.6.3",
-				"workbox-navigation-preload": "^3.6.3",
-				"workbox-precaching": "^3.6.3",
-				"workbox-range-requests": "^3.6.3",
-				"workbox-routing": "^3.6.3",
-				"workbox-strategies": "^3.6.3",
-				"workbox-streams": "^3.6.3",
-				"workbox-sw": "^3.6.3"
+				"workbox-background-sync": "^4.3.1",
+				"workbox-broadcast-update": "^4.3.1",
+				"workbox-cacheable-response": "^4.3.1",
+				"workbox-core": "^4.3.1",
+				"workbox-expiration": "^4.3.1",
+				"workbox-google-analytics": "^4.3.1",
+				"workbox-navigation-preload": "^4.3.1",
+				"workbox-precaching": "^4.3.1",
+				"workbox-range-requests": "^4.3.1",
+				"workbox-routing": "^4.3.1",
+				"workbox-strategies": "^4.3.1",
+				"workbox-streams": "^4.3.1",
+				"workbox-sw": "^4.3.1",
+				"workbox-window": "^4.3.1"
 			},
 			"dependencies": {
 				"fs-extra": {
@@ -29399,111 +27119,120 @@
 				}
 			}
 		},
-		"workbox-cache-expiration": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.6.3.tgz",
-			"integrity": "sha512-+ECNph/6doYx89oopO/UolYdDmQtGUgo8KCgluwBF/RieyA1ZOFKfrSiNjztxOrGJoyBB7raTIOlEEwZ1LaHoA==",
-			"dev": true,
-			"requires": {
-				"workbox-core": "^3.6.3"
-			}
-		},
 		"workbox-cacheable-response": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.6.3.tgz",
-			"integrity": "sha512-QpmbGA9SLcA7fklBLm06C4zFg577Dt8u3QgLM0eMnnbaVv3rhm4vbmDpBkyTqvgK/Ly8MBDQzlXDtUCswQwqqg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-4.3.1.tgz",
+			"integrity": "sha512-Rp5qlzm6z8IOvnQNkCdO9qrDgDpoPNguovs0H8C+wswLuPgSzSp9p2afb5maUt9R1uTIwOXrVQMmPfPypv+npw==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-core": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.6.3.tgz",
-			"integrity": "sha512-cx9cx0nscPkIWs8Pt98HGrS9/aORuUcSkWjG25GqNWdvD/pSe7/5Oh3BKs0fC+rUshCiyLbxW54q0hA+GqZeSQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-4.3.1.tgz",
+			"integrity": "sha512-I3C9jlLmMKPxAC1t0ExCq+QoAMd0vAAHULEgRZ7kieCdUd919n53WC0AfvokHNwqRhGn+tIIj7vcb5duCjs2Kg==",
 			"dev": true
 		},
-		"workbox-google-analytics": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.6.3.tgz",
-			"integrity": "sha512-RQBUo/6SXtIaQTRFj4RQZ9e1gAl7D8oS5S+Hi173Kk70/BgJjzPwXpC5A249Jv5YfkCOLMQCeF9A27BiD0b0ig==",
+		"workbox-expiration": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-4.3.1.tgz",
+			"integrity": "sha512-vsJLhgQsQouv9m0rpbXubT5jw0jMQdjpkum0uT+d9tTwhXcEZks7qLfQ9dGSaufTD2eimxbUOJfWLbNQpIDMPw==",
 			"dev": true,
 			"requires": {
-				"workbox-background-sync": "^3.6.3",
-				"workbox-core": "^3.6.3",
-				"workbox-routing": "^3.6.3",
-				"workbox-strategies": "^3.6.3"
+				"workbox-core": "^4.3.1"
+			}
+		},
+		"workbox-google-analytics": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-4.3.1.tgz",
+			"integrity": "sha512-xzCjAoKuOb55CBSwQrbyWBKqp35yg1vw9ohIlU2wTy06ZrYfJ8rKochb1MSGlnoBfXGWss3UPzxR5QL5guIFdg==",
+			"dev": true,
+			"requires": {
+				"workbox-background-sync": "^4.3.1",
+				"workbox-core": "^4.3.1",
+				"workbox-routing": "^4.3.1",
+				"workbox-strategies": "^4.3.1"
 			}
 		},
 		"workbox-navigation-preload": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-3.6.3.tgz",
-			"integrity": "sha512-dd26xTX16DUu0i+MhqZK/jQXgfIitu0yATM4jhRXEmpMqQ4MxEeNvl2CgjDMOHBnCVMax+CFZQWwxMx/X/PqCw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-4.3.1.tgz",
+			"integrity": "sha512-K076n3oFHYp16/C+F8CwrRqD25GitA6Rkd6+qAmLmMv1QHPI2jfDwYqrytOfKfYq42bYtW8Pr21ejZX7GvALOw==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-precaching": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.6.3.tgz",
-			"integrity": "sha512-aBqT66BuMFviPTW6IpccZZHzpA8xzvZU2OM1AdhmSlYDXOJyb1+Z6blVD7z2Q8VNtV1UVwQIdImIX+hH3C3PIw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-4.3.1.tgz",
+			"integrity": "sha512-piSg/2csPoIi/vPpp48t1q5JLYjMkmg5gsXBQkh/QYapCdVwwmKlU9mHdmy52KsDGIjVaqEUMFvEzn2LRaigqQ==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-range-requests": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.6.3.tgz",
-			"integrity": "sha512-R+yLWQy7D9aRF9yJ3QzwYnGFnGDhMUij4jVBUVtkl67oaVoP1ymZ81AfCmfZro2kpPRI+vmNMfxxW531cqdx8A==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-4.3.1.tgz",
+			"integrity": "sha512-S+HhL9+iTFypJZ/yQSl/x2Bf5pWnbXdd3j57xnb0V60FW1LVn9LRZkPtneODklzYuFZv7qK6riZ5BNyc0R0jZA==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-routing": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.6.3.tgz",
-			"integrity": "sha512-bX20i95OKXXQovXhFOViOK63HYmXvsIwZXKWbSpVeKToxMrp0G/6LZXnhg82ijj/S5yhKNRf9LeGDzaqxzAwMQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-4.3.1.tgz",
+			"integrity": "sha512-FkbtrODA4Imsi0p7TW9u9MXuQ5P4pVs1sWHK4dJMMChVROsbEltuE79fBoIk/BCztvOJ7yUpErMKa4z3uQLX+g==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-strategies": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.6.3.tgz",
-			"integrity": "sha512-Pg5eulqeKet2y8j73Yw6xTgLdElktcWExGkzDVCGqfV9JCvnGuEpz5eVsCIK70+k4oJcBCin9qEg3g3CwEIH3g==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-4.3.1.tgz",
+			"integrity": "sha512-F/+E57BmVG8dX6dCCopBlkDvvhg/zj6VDs0PigYwSN23L8hseSRwljrceU2WzTvk/+BSYICsWmRq5qHS2UYzhw==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-streams": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.6.3.tgz",
-			"integrity": "sha512-rqDuS4duj+3aZUYI1LsrD2t9hHOjwPqnUIfrXSOxSVjVn83W2MisDF2Bj+dFUZv4GalL9xqErcFW++9gH+Z27w==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-4.3.1.tgz",
+			"integrity": "sha512-4Kisis1f/y0ihf4l3u/+ndMkJkIT4/6UOacU3A4BwZSAC9pQ9vSvJpIi/WFGQRH/uPXvuVjF5c2RfIPQFSS2uA==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^3.6.3"
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"workbox-sw": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.6.3.tgz",
-			"integrity": "sha512-IQOUi+RLhvYCiv80RP23KBW/NTtIvzvjex28B8NW1jOm+iV4VIu3VXKXTA6er5/wjjuhmtB28qEAUqADLAyOSg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-4.3.1.tgz",
+			"integrity": "sha512-0jXdusCL2uC5gM3yYFT6QMBzKfBr2XTk0g5TPAV4y8IZDyVNDyj1a8uSXy3/XrvkVTmQvLN4O5k3JawGReXr9w==",
 			"dev": true
 		},
 		"workbox-webpack-plugin": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-3.6.3.tgz",
-			"integrity": "sha512-RwmKjc7HFHUFHoOlKoZUq9349u0QN3F8W5tZZU0vc1qsBZDINWXRiIBCAKvo/Njgay5sWz7z4I2adnyTo97qIQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-4.3.1.tgz",
+			"integrity": "sha512-gJ9jd8Mb8wHLbRz9ZvGN57IAmknOipD3W4XNE/Lk/4lqs5Htw4WOQgakQy/o/4CoXQlMCYldaqUg+EJ35l9MEQ==",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
+				"@babel/runtime": "^7.0.0",
 				"json-stable-stringify": "^1.0.1",
-				"workbox-build": "^3.6.3"
+				"workbox-build": "^4.3.1"
+			}
+		},
+		"workbox-window": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-4.3.1.tgz",
+			"integrity": "sha512-C5gWKh6I58w3GeSc0wp2Ne+rqVw8qwcmZnQGpjiek8A2wpbxSJb1FdCoQVO+jDJs35bFgo/WETgl1fqgsxN0Hg==",
+			"dev": true,
+			"requires": {
+				"workbox-core": "^4.3.1"
 			}
 		},
 		"worker-farm": {
@@ -29513,6 +27242,15 @@
 			"dev": true,
 			"requires": {
 				"errno": "~0.1.7"
+			}
+		},
+		"worker-rpc": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.1.1.tgz",
+			"integrity": "sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==",
+			"dev": true,
+			"requires": {
+				"microevent.ts": "~0.1.1"
 			}
 		},
 		"wrap-ansi": {
@@ -29529,15 +27267,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"write": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-			"dev": true,
-			"requires": {
-				"mkdirp": "^0.5.1"
-			}
 		},
 		"write-file-atomic": {
 			"version": "2.4.2",
@@ -29634,6 +27363,12 @@
 			"version": "9.0.7",
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
 			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+		},
+		"xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true
 		},
 		"xregexp": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
 		"jest-extended": "^0.11.2",
 		"jest-runner-concurrent": "^0.1.1",
 		"lerna": "^3.18.3",
-		"react-scripts": "^2.1.8",
+		"react-scripts": "^3.2.0",
 		"ts-jest": "^24.1.0",
 		"tsc-watch": "^4.0.0",
 		"tslint": "^5.20.0",

--- a/projects/backend/jest.json
+++ b/projects/backend/jest.json
@@ -35,5 +35,10 @@
 	],
 	"preset": "ts-jest",
 	"testMatch": null,
-	"runner": "jest-runner-concurrent"
+	"runner": "jest-runner-concurrent",
+	"globals": {
+		"ts-jest": {
+			"isolatedModules": true
+		}
+	}
 }

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"start": "npm run build && cross-env NODE_ENV=development node build/index.js",
 		"start:watch": "tsc-watch --project tsconfig.json --preserveWatchOutput --onSuccess \"cross-env NODE_ENV=development node build/index.js\"",
-		"build": "tsc --project tsconfig.json",
+		"build": "tsc --project tsconfig.json --noUnusedLocals",
 		"build:watch": "tsc --watch --preserveWatchOutput",
 		"dev": "npm run start:watch",
 		"azurite": "azurite-blob -l azurite",
@@ -17,7 +17,7 @@
 		"test:ci": "npm run test:cov && codecov",
 		"lint": "tslint --project tsconfig.json",
 		"lint:fix": "tslint --fix --project tsconfig.json",
-		"verify": "tsc --noEmit",
+		"verify": "tsc --noEmit --noUnusedLocals",
 		"tsc:version": "tsc -v && pwd"
 	},
 	"author": "Yannick Stachelscheid",

--- a/projects/backend/src/args/pagination-args.ts
+++ b/projects/backend/src/args/pagination-args.ts
@@ -1,8 +1,6 @@
 import { ArgsType, Field, ObjectType } from "type-graphql";
 import * as Relay from 'graphql-relay'
 
-export type ConnectionCursor = Relay.ConnectionCursor
-
 @ObjectType()
 export class PageInfo implements Relay.PageInfo {
 	@Field()
@@ -10,17 +8,17 @@ export class PageInfo implements Relay.PageInfo {
 	@Field()
 	public readonly hasPreviousPage!: boolean
 	@Field()
-	public readonly startCursor?: ConnectionCursor
+	public readonly startCursor?: string;
 	@Field()
-	public readonly endCursor?: ConnectionCursor
+	public readonly endCursor?: string;
 }
 
 @ArgsType()
 export class ConnectionArgs implements Relay.ConnectionArguments {
 	@Field({ nullable: true, description: 'Paginate before opaque cursor' })
-	public readonly before?: ConnectionCursor
+	public readonly before?: string;
 	@Field({ nullable: true, description: 'Paginate after opaque cursor' })
-	public readonly after?: ConnectionCursor
+	public readonly after?: string;
 	@Field({ nullable: true, description: 'Paginate first' })
 	public readonly first?: number
 	@Field({ nullable: true, description: 'Paginate last' })

--- a/projects/backend/src/index.ts
+++ b/projects/backend/src/index.ts
@@ -84,8 +84,6 @@ if (!isProductionEnvironment()) {
 		UserResolver, ShareResolver, SongResolver
 	);
 
-	const a = 5
-
 	const server = HTTPServer({
 		graphQLServer,
 		songFileService: services.songFileService,

--- a/projects/backend/src/index.ts
+++ b/projects/backend/src/index.ts
@@ -84,6 +84,8 @@ if (!isProductionEnvironment()) {
 		UserResolver, ShareResolver, SongResolver
 	);
 
+	const a = 5
+
 	const server = HTTPServer({
 		graphQLServer,
 		songFileService: services.songFileService,

--- a/projects/backend/src/relay/relay.ts
+++ b/projects/backend/src/relay/relay.ts
@@ -1,6 +1,5 @@
 import { ObjectType, Field } from "type-graphql"
 import { TypeValue } from "type-graphql/dist/decorators/types"
-import { ConnectionCursor } from "graphql-relay"
 import * as Relay from 'graphql-relay'
 import { PageInfo } from "../args/pagination-args"
 
@@ -11,7 +10,7 @@ export function connectionTypes<T extends TypeValue>(name: string, nodeType: T) 
 		public readonly node!: T
 
 		@Field({ description: 'Used in `before` and `after` args' })
-		public readonly cursor!: ConnectionCursor
+		public readonly cursor!: string
 	}
 
 	@ObjectType(`${name}Connection`)

--- a/projects/backend/tsconfig.json
+++ b/projects/backend/tsconfig.json
@@ -14,7 +14,8 @@
 		"skipLibCheck": true,
 		"rootDir": "src",
 		"suppressImplicitAnyIndexErrors": true,
-		"incremental": true
+		"incremental": true,
+		"noUnusedLocals": false
 	},
 	"include": [
 		"src/**/*"

--- a/projects/frontend/src/components/Player.tsx
+++ b/projects/frontend/src/components/Player.tsx
@@ -133,7 +133,7 @@ const PlayerSlider: React.FC<IPlayerSliderProps> = ({ progresses, onClick, progr
 	);
 }
 
-export const Player = ({ }) => {
+export const Player = () => {
 	const { play, pause, next, prev, volume, changeVolume, playing, currentSong, playpackProgress, duration, seek, bufferingProgress } = usePlayer();
 
 	const handleClickMute = () => {

--- a/projects/frontend/src/components/song-table/SongTable.tsx
+++ b/projects/frontend/src/components/song-table/SongTable.tsx
@@ -13,7 +13,7 @@ const columns = [
 		title: "Title",
 		width: 200,
 		key: "title",
-		render: (song: IShareSong) => <a href="#">{buildSongName(song)}</a>
+		render: (song: IShareSong) => <span>{buildSongName(song)}</span>
 	},
 	{
 		title: "Time",

--- a/projects/frontend/src/config.ts
+++ b/projects/frontend/src/config.ts
@@ -19,7 +19,7 @@ interface IWindowWithEnv extends Window {
 	_env_: IEnvLike;
 }
 
-const isWindowWithEnv = (obj: Window): obj is IWindowWithEnv => typeof (<any>obj)._env_ === 'object';
+const isWindowWithEnv = (obj: Window): obj is IWindowWithEnv => typeof (obj as any)._env_ === 'object';
 
 const getEnvValue = (name: string): string => isWindowWithEnv(window)
 	? window['_env_'][name]

--- a/projects/frontend/src/graphql/programmatic/get-song-mediaurl.ts
+++ b/projects/frontend/src/graphql/programmatic/get-song-mediaurl.ts
@@ -15,5 +15,5 @@ export const getSongMediaUrls = (client: ApolloClient<unknown>) => async (shareI
 		return response.data.share.song.sources;
 	}
 
-	throw `Cannot fetch media url for song ${songID}`;
+	throw new Error(`Cannot fetch media url for song ${songID}`);
 }

--- a/projects/frontend/src/pages/login/LoginForm.tsx
+++ b/projects/frontend/src/pages/login/LoginForm.tsx
@@ -55,9 +55,9 @@ const LoginForm = ({
 					valuePropName: "checked",
 					initialValue: true
 				})(<Checkbox>Remember me</Checkbox>)}
-				<a className="login-form-forgot" href="">
+				<Button type="link">
 					Forgot password
-        </a>
+        		</Button>
 			</Form.Item>
 			<Form.Item>
 				<Button

--- a/projects/frontend/src/pages/share/SongsView.tsx
+++ b/projects/frontend/src/pages/share/SongsView.tsx
@@ -12,7 +12,7 @@ import { ISongSearchFilter, allMatchingOptions } from "../../components/song-tab
 const tokenizeQuery = (query: string) => query
 	.trim()
 	.toLowerCase()
-	.replace(/[&\/\\#,+()$~%.'":*?<>{}!]/g, '')
+	.replace(/[&/#,+()$~%.'":*?<>{}!]/g, '')
 	.split(' ')
 	.map(token => token.trim())
 	.filter(token => token.length > 0)


### PR DESCRIPTION
* upgrade react-scripts to 3.2.0 and fix corresponding lint warnings
* ts-jest enable isolated modules to speed up tests
* disable noUnusedLocals but add check for build and verify script
* add important notes to readme test section
* small readme changes

Closes #874 
Relates to #814 