### PR TITLE
fix: frontend edit song in share playlist view cache invalidation

### DIFF
--- a/projects/frontend/src/components/modals/song-modal/SongForm.tsx
+++ b/projects/frontend/src/components/modals/song-modal/SongForm.tsx
@@ -5,16 +5,9 @@ import { Formik } from "formik"
 import { Form, Input, Row, Col, DatePicker, Switch, Modal, Select } from "antd"
 import { EditableTagGroup } from "../../form/EditableTagGroup"
 import moment from "moment"
-import {
-	UPDATE_SONG,
-	ISongUpdateInput,
-	IUpdateSongData,
-	makeUpdateSongCache,
-} from "../../../graphql/mutations/update-song-mutation"
+import { ISongUpdateInput, useUpdateSongMutation } from "../../../graphql/mutations/update-song-mutation"
 import { Nullable } from "../../../types/Nullable"
 import { buildSongName } from "../../../utils/songname-builder"
-import { MutationUpdaterFn } from "apollo-client"
-import { useMutation } from "react-apollo"
 
 interface ISongFormProps {
 	song: IScopedSong
@@ -44,14 +37,11 @@ export const SongForm = ({
 		[songTypes],
 	)
 
-	const updateSongCache = makeUpdateSongCache(song.libraryID, playlistID)
-
-	const songMutationOnUpdate: MutationUpdaterFn<IUpdateSongData> = (cache, data) => {
-		updateSongCache(cache, data)
-		closeForm()
-	}
-
-	const [updateSongMutation, { loading }] = useMutation(UPDATE_SONG, { update: songMutationOnUpdate })
+	const [updateSongMutation, { loading }] = useUpdateSongMutation(song, playlistID, {
+		onCompleted: () => {
+			closeForm()
+		},
+	})
 
 	const updateSong = useCallback(
 		(values: IScopedSong) => {

--- a/projects/frontend/src/components/modals/song-modal/SongForm.tsx
+++ b/projects/frontend/src/components/modals/song-modal/SongForm.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useCallback } from "react"
-import "./song-modal.css"
 import { IGenre, ISongType, IArtist, IScopedSong } from "../../../graphql/types"
 import { Formik } from "formik"
 import { Form, Input, Row, Col, DatePicker, Switch, Modal, Select } from "antd"
@@ -8,6 +7,17 @@ import moment from "moment"
 import { ISongUpdateInput, useUpdateSongMutation } from "../../../graphql/mutations/update-song-mutation"
 import { Nullable } from "../../../types/Nullable"
 import { buildSongName } from "../../../utils/songname-builder"
+import styled from "styled-components"
+
+const StyledModal = styled(Modal)`
+	& .ant-form-item-label {
+		line-height: 20px;
+	}
+
+	& .ant-row.ant-form-item {
+		margin-bottom: 4px;
+	}
+`
 
 interface ISongFormProps {
 	song: IScopedSong
@@ -60,7 +70,7 @@ export const SongForm = ({
 		<Formik initialValues={song} onSubmit={updateSong} validate={validateSong} initialErrors={validateSong(song)}>
 			{({ values, errors, handleChange, handleBlur, setFieldValue, submitForm }) => {
 				return (
-					<Modal
+					<StyledModal
 						title={buildSongName(song)}
 						visible={true}
 						onCancel={closeForm}
@@ -69,170 +79,168 @@ export const SongForm = ({
 						okText={readOnly ? "OK" : "Save"}
 						okButtonProps={{ loading }}
 					>
-						<div id="songmodal">
-							<Form>
-								<Form.Item label="Title" validateStatus={errors.title ? "error" : "success"}>
-									<Input
-										placeholder="Song title"
-										name="title"
-										value={values.title}
-										onChange={handleChange}
-										onBlur={handleBlur}
-										readOnly={readOnly}
-									/>
-								</Form.Item>
-								<Form.Item label="Artists">
-									<EditableTagGroup
-										values={values.artists}
-										onValuesChange={(newValues) => setFieldValue("artists", newValues)}
-										placeholder="Add artist"
-										datasource={artistsDataSource}
-										readOnly={readOnly}
-									/>
-								</Form.Item>
-								<Form.Item label="Remixer">
-									<EditableTagGroup
-										values={values.remixer}
-										onValuesChange={(newValues) => setFieldValue("remixer", newValues)}
-										placeholder="Add remixer"
-										datasource={artistsDataSource}
-										readOnly={readOnly}
-									/>
-								</Form.Item>
-								<Form.Item label="Featurings">
-									<EditableTagGroup
-										values={values.featurings}
-										onValuesChange={(newValues) => setFieldValue("featurings", newValues)}
-										placeholder="Add featurings"
-										datasource={artistsDataSource}
-										readOnly={readOnly}
-									/>
-								</Form.Item>
-								<Row>
-									<Col span={12} style={{ paddingRight: 20 }}>
-										<Form.Item label="Genres">
-											<EditableTagGroup
-												values={values.genres}
-												onValuesChange={(newValues) => setFieldValue("genres", newValues)}
-												placeholder="Add genre"
-												datasource={genresDataSource}
-												readOnly={readOnly}
-											/>
-										</Form.Item>
-									</Col>
-									<Col span={12} style={{ paddingRight: 20 }}>
-										<Form.Item label="Suffix" validateStatus={errors.suffix ? "error" : "success"}>
-											<Input
-												placeholder="Song suffix"
-												name="suffix"
-												value={values.suffix || ""}
-												onChange={handleChange}
-												onBlur={handleBlur}
-												readOnly={readOnly}
-											/>
-										</Form.Item>
-									</Col>
-								</Row>
-								<Row>
-									<Col span={12} style={{ paddingRight: 20 }}>
-										<Form.Item label="Year" validateStatus={errors.year ? "error" : "success"}>
-											<Input
-												placeholder="Year"
-												name="year"
-												value={values.year || ""}
-												onChange={handleChange}
-												onBlur={handleBlur}
-												type="number"
-												readOnly={readOnly}
-											/>
-										</Form.Item>
-									</Col>
-									<Col span={12} style={{ paddingRight: 20 }}>
-										<Form.Item label="BPM" validateStatus={errors.bpm ? "error" : "success"}>
-											<Input
-												placeholder="BPM"
-												name="bpm"
-												value={values.bpm || ""}
-												onChange={handleChange}
-												onBlur={handleBlur}
-												type="number"
-												readOnly={readOnly}
-											/>
-										</Form.Item>
-									</Col>
-								</Row>
-								<Row>
-									<Col span={12} style={{ paddingRight: 20 }}>
-										<Form.Item
-											label="Type"
-											validateStatus={errors.type ? "error" : "success"}
-											hasFeedback={!!errors.type}
+						<Form>
+							<Form.Item label="Title" validateStatus={errors.title ? "error" : "success"}>
+								<Input
+									placeholder="Song title"
+									name="title"
+									value={values.title}
+									onChange={handleChange}
+									onBlur={handleBlur}
+									readOnly={readOnly}
+								/>
+							</Form.Item>
+							<Form.Item label="Artists">
+								<EditableTagGroup
+									values={values.artists}
+									onValuesChange={(newValues) => setFieldValue("artists", newValues)}
+									placeholder="Add artist"
+									datasource={artistsDataSource}
+									readOnly={readOnly}
+								/>
+							</Form.Item>
+							<Form.Item label="Remixer">
+								<EditableTagGroup
+									values={values.remixer}
+									onValuesChange={(newValues) => setFieldValue("remixer", newValues)}
+									placeholder="Add remixer"
+									datasource={artistsDataSource}
+									readOnly={readOnly}
+								/>
+							</Form.Item>
+							<Form.Item label="Featurings">
+								<EditableTagGroup
+									values={values.featurings}
+									onValuesChange={(newValues) => setFieldValue("featurings", newValues)}
+									placeholder="Add featurings"
+									datasource={artistsDataSource}
+									readOnly={readOnly}
+								/>
+							</Form.Item>
+							<Row>
+								<Col span={12} style={{ paddingRight: 20 }}>
+									<Form.Item label="Genres">
+										<EditableTagGroup
+											values={values.genres}
+											onValuesChange={(newValues) => setFieldValue("genres", newValues)}
+											placeholder="Add genre"
+											datasource={genresDataSource}
+											readOnly={readOnly}
+										/>
+									</Form.Item>
+								</Col>
+								<Col span={12} style={{ paddingRight: 20 }}>
+									<Form.Item label="Suffix" validateStatus={errors.suffix ? "error" : "success"}>
+										<Input
+											placeholder="Song suffix"
+											name="suffix"
+											value={values.suffix || ""}
+											onChange={handleChange}
+											onBlur={handleBlur}
+											readOnly={readOnly}
+										/>
+									</Form.Item>
+								</Col>
+							</Row>
+							<Row>
+								<Col span={12} style={{ paddingRight: 20 }}>
+									<Form.Item label="Year" validateStatus={errors.year ? "error" : "success"}>
+										<Input
+											placeholder="Year"
+											name="year"
+											value={values.year || ""}
+											onChange={handleChange}
+											onBlur={handleBlur}
+											type="number"
+											readOnly={readOnly}
+										/>
+									</Form.Item>
+								</Col>
+								<Col span={12} style={{ paddingRight: 20 }}>
+									<Form.Item label="BPM" validateStatus={errors.bpm ? "error" : "success"}>
+										<Input
+											placeholder="BPM"
+											name="bpm"
+											value={values.bpm || ""}
+											onChange={handleChange}
+											onBlur={handleBlur}
+											type="number"
+											readOnly={readOnly}
+										/>
+									</Form.Item>
+								</Col>
+							</Row>
+							<Row>
+								<Col span={12} style={{ paddingRight: 20 }}>
+									<Form.Item
+										label="Type"
+										validateStatus={errors.type ? "error" : "success"}
+										hasFeedback={!!errors.type}
+									>
+										<Select
+											value={values.type}
+											onSelect={(value: string | null) => setFieldValue("type", value)}
+											disabled={readOnly}
+											style={{ width: 200 }}
 										>
-											<Select
-												value={values.type}
-												onSelect={(value: string | null) => setFieldValue("type", value)}
-												disabled={readOnly}
-												style={{ width: 200 }}
-											>
-												{songTypeOptions.map((songType) => (
-													<Select.Option key={songType.value} value={songType.value}>
-														{songType.label}
-													</Select.Option>
-												))}
-											</Select>
-										</Form.Item>
-									</Col>
-									<Col span={12} style={{ paddingRight: 20 }}>
-										<Form.Item
-											label="Release Date"
-											validateStatus={errors.releaseDate ? "error" : "success"}
-										>
-											<DatePicker
-												value={values.releaseDate ? moment(values.releaseDate) : undefined}
-												onChange={(e) => setFieldValue("releaseDate", e!.toISOString())}
-												placeholder="Release Date"
-												disabled={readOnly}
-											/>
-										</Form.Item>
-									</Col>
-								</Row>
-								<Row>
-									<Col span={12} style={{ paddingRight: 20 }}>
-										<Form.Item label="Is rip" validateStatus={errors.isRip ? "error" : "success"}>
-											<Switch
-												checked={values.isRip}
-												onChange={(e) => setFieldValue("isRip", e)}
-												disabled={readOnly}
-											/>
-										</Form.Item>
-									</Col>
-								</Row>
-								<Row>
-									<Col span={12} style={{ paddingRight: 20 }}>
-										<Form.Item label="Tags">
-											<EditableTagGroup
-												values={values.tags}
-												onValuesChange={(newValues) => setFieldValue("tags", newValues)}
-												placeholder="Add tag"
-												datasource={tags}
-												readOnly={readOnly}
-											/>
-										</Form.Item>
-									</Col>
-									<Col span={12} style={{ paddingRight: 20 }}>
-										<Form.Item label="Record Labels">
-											<EditableTagGroup
-												values={values.labels}
-												onValuesChange={(newValues) => setFieldValue("labels", newValues)}
-												placeholder="Add label"
-												readOnly={readOnly}
-											/>
-										</Form.Item>
-									</Col>
-								</Row>
-							</Form>
-						</div>
-					</Modal>
+											{songTypeOptions.map((songType) => (
+												<Select.Option key={songType.value} value={songType.value}>
+													{songType.label}
+												</Select.Option>
+											))}
+										</Select>
+									</Form.Item>
+								</Col>
+								<Col span={12} style={{ paddingRight: 20 }}>
+									<Form.Item
+										label="Release Date"
+										validateStatus={errors.releaseDate ? "error" : "success"}
+									>
+										<DatePicker
+											value={values.releaseDate ? moment(values.releaseDate) : undefined}
+											onChange={(e) => setFieldValue("releaseDate", e!.toISOString())}
+											placeholder="Release Date"
+											disabled={readOnly}
+										/>
+									</Form.Item>
+								</Col>
+							</Row>
+							<Row>
+								<Col span={12} style={{ paddingRight: 20 }}>
+									<Form.Item label="Is rip" validateStatus={errors.isRip ? "error" : "success"}>
+										<Switch
+											checked={values.isRip}
+											onChange={(e) => setFieldValue("isRip", e)}
+											disabled={readOnly}
+										/>
+									</Form.Item>
+								</Col>
+							</Row>
+							<Row>
+								<Col span={12} style={{ paddingRight: 20 }}>
+									<Form.Item label="Tags">
+										<EditableTagGroup
+											values={values.tags}
+											onValuesChange={(newValues) => setFieldValue("tags", newValues)}
+											placeholder="Add tag"
+											datasource={tags}
+											readOnly={readOnly}
+										/>
+									</Form.Item>
+								</Col>
+								<Col span={12} style={{ paddingRight: 20 }}>
+									<Form.Item label="Record Labels">
+										<EditableTagGroup
+											values={values.labels}
+											onValuesChange={(newValues) => setFieldValue("labels", newValues)}
+											placeholder="Add label"
+											readOnly={readOnly}
+										/>
+									</Form.Item>
+								</Col>
+							</Row>
+						</Form>
+					</StyledModal>
 				)
 			}}
 		</Formik>

--- a/projects/frontend/src/components/modals/song-modal/song-modal.css
+++ b/projects/frontend/src/components/modals/song-modal/song-modal.css
@@ -1,7 +1,0 @@
-#songmodal .ant-form-item-label{
-	line-height: 20px;
-}
-
-#songmodal .ant-row.ant-form-item{
-	margin-bottom: 4px;
-}

--- a/projects/frontend/src/graphql/client/mutations/token-mutation.ts
+++ b/projects/frontend/src/graphql/client/mutations/token-mutation.ts
@@ -1,8 +1,7 @@
 import gql from "graphql-tag"
-import { useMutation } from "@apollo/react-hooks"
+import { useMutation, MutationHookOptions } from "@apollo/react-hooks"
 import { useCallback } from "react"
 import { MutationResult } from "@apollo/react-common"
-import { IMutationOptions } from "../../hook-types"
 import { MutationUpdaterFn } from "apollo-client"
 
 type Token = string | null
@@ -18,7 +17,7 @@ const UPDATE_TOKENS = gql`
 	}
 `
 
-export const useSetAuthTokens = (opts?: IMutationOptions<void>) => {
+export const useSetAuthTokens = (opts?: MutationHookOptions<void, IShareVariables>) => {
 	const [setAuthTokensMutation, other] = useMutation<void, IShareVariables>(UPDATE_TOKENS, opts)
 
 	const makeUpdateCache = useCallback(

--- a/projects/frontend/src/graphql/hook-types.ts
+++ b/projects/frontend/src/graphql/hook-types.ts
@@ -1,6 +1,0 @@
-import { ApolloError } from "apollo-client"
-
-export interface IMutationOptions<TData = unknown> {
-	onCompleted?: (data: TData) => any
-	onError?: (error: ApolloError) => any
-}

--- a/projects/frontend/src/graphql/mutations/accept-invitation-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/accept-invitation-mutation.ts
@@ -1,8 +1,7 @@
 import { IUser, userKeys } from "../types"
 import gql from "graphql-tag"
-import { useMutation, MutationResult } from "react-apollo"
+import { useMutation, MutationResult, MutationHookOptions } from "react-apollo"
 import { useCallback } from "react"
-import { IMutationOptions } from "../hook-types"
 
 interface IAcceptInvitationData {
 	acceptInvitation: {
@@ -32,7 +31,7 @@ const ACCEPT_INVITATION = gql`
 	}
 `
 
-export const useAcceptInvitation = (opts?: IMutationOptions<IAcceptInvitationData>) => {
+export const useAcceptInvitation = (opts?: MutationHookOptions<IAcceptInvitationData, IAcceptInvitationVariables>) => {
 	const [acceptInvitationMutation, other] = useMutation<IAcceptInvitationData, IAcceptInvitationVariables>(
 		ACCEPT_INVITATION,
 		opts,

--- a/projects/frontend/src/graphql/mutations/add-songs-to-playlist.ts
+++ b/projects/frontend/src/graphql/mutations/add-songs-to-playlist.ts
@@ -1,11 +1,10 @@
 import { IPlaylistSong, playlistSongKeys } from "../types"
-import { useMutation } from "@apollo/react-hooks"
+import { useMutation, MutationHookOptions } from "@apollo/react-hooks"
 import gql from "graphql-tag"
 import { useCallback } from "react"
 import { MutationUpdaterFn } from "apollo-client"
 import { IGetPlaylistSongsData, IGetPlaylistSongsVariables, PLAYLIST_WITH_SONGS } from "../queries/playlist-songs"
 import { IGetPlaylistsData, IGetPlaylistsVariables, GET_SHARE_PLAYLISTS } from "../queries/playlists-query"
-import { IMutationOptions } from "../hook-types"
 
 export interface IAddSongsToPlaylistVariables {
 	shareID: string
@@ -25,7 +24,9 @@ export const ADD_SONGS_TO_PLAYLIST = gql`
 	}
 `
 
-export const useAddSongsToPlaylist = (opts?: IMutationOptions<IAddSongsToPlaylistData>) => {
+export const useAddSongsToPlaylist = (
+	opts?: MutationHookOptions<IAddSongsToPlaylistData, IAddSongsToPlaylistVariables>,
+) => {
 	const [invokeMutation] = useMutation<IAddSongsToPlaylistData, IAddSongsToPlaylistVariables>(
 		ADD_SONGS_TO_PLAYLIST,
 		opts,

--- a/projects/frontend/src/graphql/mutations/change-password-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/change-password-mutation.ts
@@ -1,7 +1,6 @@
 import gql from "graphql-tag"
-import { useMutation, MutationResult } from "react-apollo"
+import { useMutation, MutationResult, MutationHookOptions } from "react-apollo"
 import { useCallback } from "react"
-import { IMutationOptions } from "../hook-types"
 
 interface IChangePasswordData {
 	changePassword: boolean
@@ -22,7 +21,7 @@ const CHANGE_PASSWORD = gql`
 	}
 `
 
-export const useChangePassword = (opts?: IMutationOptions<IChangePasswordData>) => {
+export const useChangePassword = (opts?: MutationHookOptions<IChangePasswordData, IChangePasswordVariables>) => {
 	const [changePasswordMutation, other] = useMutation<IChangePasswordData, IChangePasswordVariables>(
 		CHANGE_PASSWORD,
 		opts,

--- a/projects/frontend/src/graphql/mutations/create-playlist-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/create-playlist-mutation.ts
@@ -5,12 +5,11 @@ import {
 	IGetPlaylistsVariables,
 	GET_SHARE_PLAYLISTS,
 } from "../queries/playlists-query"
-import { useMutation } from "@apollo/react-hooks"
+import { useMutation, MutationHookOptions } from "@apollo/react-hooks"
 import { MutationUpdaterFn } from "apollo-client/core/watchQueryOptions"
 import { IPlaylist } from "../types"
 import { useCallback } from "react"
 import { MutationResult } from "react-apollo"
-import { IMutationOptions } from "../hook-types"
 
 export interface ICreatePlaylistVariables {
 	shareID: string
@@ -29,7 +28,7 @@ export const CREATE_PLAYLIST = gql`
 	}
 `
 
-export const useCreatePlaylist = (opts?: IMutationOptions<ICreatePlaylistData>) => {
+export const useCreatePlaylist = (opts?: MutationHookOptions<ICreatePlaylistData, ICreatePlaylistVariables>) => {
 	const makeUpdatePlaylistCache = useCallback(
 		(shareID: string): MutationUpdaterFn<ICreatePlaylistData> => (cache, { data }) => {
 			const currentPlaylists = cache.readQuery<IGetPlaylistsData, IGetPlaylistsVariables>({

--- a/projects/frontend/src/graphql/mutations/create-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/create-share-mutation.ts
@@ -1,7 +1,6 @@
 import { IShare, shareKeys } from "../types"
 import gql from "graphql-tag"
-import { useMutation } from "react-apollo"
-import { IMutationOptions } from "../hook-types"
+import { useMutation, MutationHookOptions } from "react-apollo"
 import { useCallback } from "react"
 import { MutationUpdaterFn } from "apollo-client"
 import { IGetSharesData, IGetSharesVariables, GET_SHARES } from "../queries/shares-query"
@@ -22,7 +21,7 @@ const CREATE_SHARE = gql`
 	}
 `
 
-export const useCreateShare = (opts?: IMutationOptions<ICreateShareData>) => {
+export const useCreateShare = (opts?: MutationHookOptions<ICreateShareData, ICreateShareVariables>) => {
 	const updateSharesCache = useCallback<MutationUpdaterFn<ICreateShareData>>((cache, { data }) => {
 		if (!data) return
 

--- a/projects/frontend/src/graphql/mutations/delete-playlist-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/delete-playlist-mutation.ts
@@ -1,6 +1,5 @@
 import gql from "graphql-tag"
-import { IMutationOptions } from "../hook-types"
-import { useMutation, MutationResult } from "react-apollo"
+import { useMutation, MutationResult, MutationHookOptions } from "react-apollo"
 import { useCallback } from "react"
 import { MutationUpdaterFn } from "apollo-client"
 import { IGetPlaylistsData, IGetPlaylistsVariables, GET_SHARE_PLAYLISTS } from "../queries/playlists-query"
@@ -20,7 +19,7 @@ const DELETE_PLAYLIST = gql`
 	}
 `
 
-export const useDeletePlaylist = (opts?: IMutationOptions<IDeletePlaylistData>) => {
+export const useDeletePlaylist = (opts?: MutationHookOptions<IDeletePlaylistData, IDeletePlaylistVariables>) => {
 	const [deletePlaylistMutation, other] = useMutation<IDeletePlaylistData, IDeletePlaylistVariables>(
 		DELETE_PLAYLIST,
 		opts,

--- a/projects/frontend/src/graphql/mutations/delete-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/delete-share-mutation.ts
@@ -1,6 +1,5 @@
 import gql from "graphql-tag"
-import { useMutation, MutationResult } from "react-apollo"
-import { IMutationOptions } from "../hook-types"
+import { useMutation, MutationResult, MutationHookOptions } from "react-apollo"
 import { useCallback } from "react"
 import { MutationUpdaterFn } from "apollo-client"
 import { IGetSharesData, IGetSharesVariables, GET_SHARES } from "../queries/shares-query"
@@ -19,7 +18,7 @@ const DELETE_SHARE = gql`
 	}
 `
 
-export const useDeleteShare = (opts?: IMutationOptions<IDeleteShareData>) => {
+export const useDeleteShare = (opts?: MutationHookOptions<IDeleteShareData, IDeleteShareVariables>) => {
 	const makeUpdateSharesCache = useCallback(
 		(shareID: string): MutationUpdaterFn<IDeleteShareData> => (cache, { data }) => {
 			if (!data) return

--- a/projects/frontend/src/graphql/mutations/invite-to-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/invite-to-share-mutation.ts
@@ -1,6 +1,5 @@
 import gql from "graphql-tag"
-import { useMutation } from "react-apollo"
-import { IMutationOptions } from "../hook-types"
+import { useMutation, MutationHookOptions } from "react-apollo"
 
 interface IInviteToShareData {
 	inviteToShare: string | null
@@ -19,7 +18,7 @@ const INVITE_TO_SHARE = gql`
 	}
 `
 
-export const useInviteToShare = (opts?: IMutationOptions<IInviteToShareData>) => {
+export const useInviteToShare = (opts?: MutationHookOptions<IInviteToShareData, IInviteToShareVariables>) => {
 	const hook = useMutation<IInviteToShareData, IInviteToShareVariables>(INVITE_TO_SHARE, opts)
 
 	return hook

--- a/projects/frontend/src/graphql/mutations/leave-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/leave-share-mutation.ts
@@ -2,8 +2,7 @@ import gql from "graphql-tag"
 import { useCallback } from "react"
 import { MutationUpdaterFn } from "apollo-client"
 import { IGetSharesData, IGetSharesVariables, GET_SHARES } from "../queries/shares-query"
-import { useMutation, MutationResult } from "react-apollo"
-import { IMutationOptions } from "../hook-types"
+import { useMutation, MutationResult, MutationHookOptions } from "react-apollo"
 
 interface ILeaveShareData {
 	leaveShare: boolean
@@ -21,7 +20,7 @@ const LEAVE_SHARE = gql`
 	}
 `
 
-export const useLeaveShare = (opts?: IMutationOptions<ILeaveShareData>) => {
+export const useLeaveShare = (opts?: MutationHookOptions<ILeaveShareData, ILeaveShareVariables>) => {
 	const makeUpdateSharesCache = useCallback(
 		(shareID: string): MutationUpdaterFn<ILeaveShareData> => (cache, { data }) => {
 			if (!data) return

--- a/projects/frontend/src/graphql/mutations/login-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/login-mutation.ts
@@ -1,7 +1,6 @@
 import gql from "graphql-tag"
-import { useMutation } from "@apollo/react-hooks"
+import { useMutation, MutationHookOptions } from "@apollo/react-hooks"
 import { DataProxy } from "apollo-cache"
-import { IMutationOptions } from "../hook-types"
 import { useCallback } from "react"
 import { MutationUpdaterFn } from "apollo-client"
 import { MutationResult } from "react-apollo"
@@ -27,7 +26,7 @@ export const LOGIN = gql`
 	}
 `
 
-export const useLogin = (opts?: IMutationOptions<ILoginData>) => {
+export const useLogin = (opts?: MutationHookOptions<ILoginData, ILoginVariables>) => {
 	const [loginMutation, other] = useMutation<ILoginData, ILoginVariables>(LOGIN, opts)
 
 	const updateCache = useCallback<MutationUpdaterFn<ILoginData>>((cache: DataProxy, { data }) => {

--- a/projects/frontend/src/graphql/mutations/remove-song-from-library-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/remove-song-from-library-mutation.ts
@@ -1,9 +1,8 @@
 import gql from "graphql-tag"
-import { useMutation, MutationResult } from "react-apollo"
+import { useMutation, MutationResult, MutationHookOptions } from "react-apollo"
 import { useCallback } from "react"
 import { MutationUpdaterFn } from "apollo-client"
 import { IGetShareWithSongsData, IGetShareWithSongsVariables, GET_SHARE_WITH_SONGS } from "../queries/share-songs-query"
-import { IMutationOptions } from "../hook-types"
 
 interface IRemoveSongFromLibraryData {
 	removeSongFromLibrary: boolean
@@ -22,7 +21,9 @@ const REMOVE_SONG_FROM_LIBRARY = gql`
 	}
 `
 
-export const useRemoveSongFromLibrary = (opts?: IMutationOptions<IRemoveSongFromLibraryData>) => {
+export const useRemoveSongFromLibrary = (
+	opts?: MutationHookOptions<IRemoveSongFromLibraryData, IRemoveSongFromLibraryVariables>,
+) => {
 	const [removeSongFromLibraryMutation, other] = useMutation<
 		IRemoveSongFromLibraryData,
 		IRemoveSongFromLibraryVariables

--- a/projects/frontend/src/graphql/mutations/remove-songs-from-playlist-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/remove-songs-from-playlist-mutation.ts
@@ -1,10 +1,9 @@
 import { IPlaylistSong, playlistSongKeys } from "../types"
 import gql from "graphql-tag"
-import { useMutation, MutationResult } from "react-apollo"
+import { useMutation, MutationResult, MutationHookOptions } from "react-apollo"
 import { useCallback } from "react"
 import { MutationUpdaterFn } from "apollo-client"
 import { IGetPlaylistSongsData, IGetPlaylistSongsVariables, PLAYLIST_WITH_SONGS } from "../queries/playlist-songs"
-import { IMutationOptions } from "../hook-types"
 
 interface IRemoveSongsFromPlaylistData {
 	removeSongsFromPlaylist: IPlaylistSong[]
@@ -24,7 +23,9 @@ const REMOVE_SONGS_FROM_PLAYLIST = gql`
 	}
 `
 
-export const useRemoveSongsFromPlaylist = (opts?: IMutationOptions<IRemoveSongsFromPlaylistData>) => {
+export const useRemoveSongsFromPlaylist = (
+	opts?: MutationHookOptions<IRemoveSongsFromPlaylistData, IRemoveSongsFromPlaylistVariables>,
+) => {
 	const [removeSongsFromPlaylistMutation, other] = useMutation<
 		IRemoveSongsFromPlaylistData,
 		IRemoveSongsFromPlaylistVariables

--- a/projects/frontend/src/graphql/mutations/rename-share-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/rename-share-mutation.ts
@@ -1,6 +1,5 @@
 import gql from "graphql-tag"
-import { useMutation } from "react-apollo"
-import { IMutationOptions } from "../hook-types"
+import { useMutation, MutationHookOptions } from "react-apollo"
 import { IShare, shareKeys } from "../types"
 
 interface IRenameShareData {
@@ -20,7 +19,7 @@ const RENAME_SHARE = gql`
 	}
 `
 
-export const useRenameShare = (opts?: IMutationOptions<IRenameShareData>) => {
+export const useRenameShare = (opts?: MutationHookOptions<IRenameShareData, IRenameShareVariables>) => {
 	const hook = useMutation<IRenameShareData, IRenameShareVariables>(RENAME_SHARE, opts)
 
 	return hook

--- a/projects/frontend/src/graphql/mutations/restore-password-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/restore-password-mutation.ts
@@ -1,6 +1,5 @@
 import gql from "graphql-tag"
-import { IMutationOptions } from "../hook-types"
-import { useMutation, MutationResult } from "react-apollo"
+import { useMutation, MutationResult, MutationHookOptions } from "react-apollo"
 import { useCallback } from "react"
 
 interface IRestorePasswordData {
@@ -23,7 +22,7 @@ const RESTORE_PASSWORD = gql`
 	}
 `
 
-export const useRestorePassword = (opts?: IMutationOptions<IRestorePasswordData>) => {
+export const useRestorePassword = (opts?: MutationHookOptions<IRestorePasswordData, IRestorePasswordVariables>) => {
 	const [restorePasswordMutation, other] = useMutation<IRestorePasswordData, IRestorePasswordVariables>(
 		RESTORE_PASSWORD,
 		opts,

--- a/projects/frontend/src/graphql/mutations/revoke-invitation-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/revoke-invitation-mutation.ts
@@ -1,6 +1,5 @@
 import gql from "graphql-tag"
-import { IMutationOptions } from "../hook-types"
-import { useMutation } from "react-apollo"
+import { useMutation, MutationHookOptions } from "react-apollo"
 
 interface IRevokeInvitationData {
 	revokeInvitation: boolean
@@ -19,7 +18,7 @@ const REVOKE_INVITATION = gql`
 	}
 `
 
-export const useRevokeInvitation = (opts?: IMutationOptions<IRevokeInvitationData>) => {
+export const useRevokeInvitation = (opts?: MutationHookOptions<IRevokeInvitationData, IRevokeInvitationVariables>) => {
 	const hook = useMutation<IRevokeInvitationData, IRevokeInvitationVariables>(REVOKE_INVITATION, opts)
 
 	return hook

--- a/projects/frontend/src/graphql/mutations/update-playlist-song-order.ts
+++ b/projects/frontend/src/graphql/mutations/update-playlist-song-order.ts
@@ -1,7 +1,6 @@
 import { playlistSongKeys, IScopedPlaylistSong } from "../types"
 import gql from "graphql-tag"
-import { IMutationOptions } from "../hook-types"
-import { useMutation, MutationResult } from "react-apollo"
+import { useMutation, MutationResult, MutationHookOptions } from "react-apollo"
 import { useCallback } from "react"
 import { MutationUpdaterFn } from "apollo-client"
 import { IGetPlaylistSongsData, IGetPlaylistSongsVariables, PLAYLIST_WITH_SONGS } from "../queries/playlist-songs"
@@ -27,7 +26,9 @@ const UPDATE_PLAYLIST_SONG_ORDER = gql`
 	}
 `
 
-export const useUpdatePlaylistSongOrder = (opts?: IMutationOptions<IUpdatePlaylistSongOrderData>) => {
+export const useUpdatePlaylistSongOrder = (
+	opts?: MutationHookOptions<IUpdatePlaylistSongOrderData, IUpdatePlaylistSongOrderVariables>,
+) => {
 	const [updatePlaylistSongOrderMutation, other] = useMutation<
 		IUpdatePlaylistSongOrderData,
 		IUpdatePlaylistSongOrderVariables

--- a/projects/frontend/src/graphql/mutations/update-song-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/update-song-mutation.ts
@@ -4,9 +4,8 @@ import { shareSongKeys, IBaseSong, IScopedSong } from "../types"
 import { IGetPlaylistSongsData, IGetPlaylistSongsVariables, PLAYLIST_WITH_SONGS } from "../queries/playlist-songs"
 import { addArtistsToCache } from "../programmatic/add-artist-to-cache"
 import { useMemo } from "react"
-import { useMutation } from "react-apollo"
+import { useMutation, MutationHookOptions } from "react-apollo"
 import { MutationUpdaterFn } from "apollo-client"
-import { IMutationOptions } from "../hook-types"
 
 export const UPDATE_SONG = gql`
 	mutation UpdateSong($shareID: String!, $songID: String!, $song: SongUpdateInput!){
@@ -84,7 +83,7 @@ const makeUpdateSongCache = (shareID: string, playlistID?: string): MutationUpda
 export const useUpdateSongMutation = (
 	song: IScopedSong,
 	playlistID?: string,
-	opts?: IMutationOptions<IUpdateSongData>,
+	opts?: MutationHookOptions<IUpdateSongData, IUpdateSongVariables>,
 ) => {
 	const updateSongCache = useMemo(() => makeUpdateSongCache(song.shareID, playlistID), [song.shareID, playlistID])
 

--- a/projects/frontend/src/graphql/mutations/update-song-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/update-song-mutation.ts
@@ -1,9 +1,12 @@
 import gql from "graphql-tag"
 import { Nullable } from "../../types/Nullable"
-import { shareSongKeys, IBaseSong } from "../types"
-import { MutationUpdaterFn } from "apollo-client/core/watchQueryOptions"
+import { shareSongKeys, IBaseSong, IScopedSong } from "../types"
 import { IGetPlaylistSongsData, IGetPlaylistSongsVariables, PLAYLIST_WITH_SONGS } from "../queries/playlist-songs"
 import { addArtistsToCache } from "../programmatic/add-artist-to-cache"
+import { useMemo } from "react"
+import { useMutation } from "react-apollo"
+import { MutationUpdaterFn } from "apollo-client"
+import { IMutationOptions } from "../hook-types"
 
 export const UPDATE_SONG = gql`
 	mutation UpdateSong($shareID: String!, $songID: String!, $song: SongUpdateInput!){
@@ -39,7 +42,7 @@ export interface IUpdateSongData {
 	updateSong: IBaseSong
 }
 
-export const makeUpdateSongCache = (shareID: string, playlistID?: string): MutationUpdaterFn<IUpdateSongData> => (
+const makeUpdateSongCache = (shareID: string, playlistID?: string): MutationUpdaterFn<IUpdateSongData> => (
 	cache,
 	{ data },
 ) => {
@@ -75,4 +78,16 @@ export const makeUpdateSongCache = (shareID: string, playlistID?: string): Mutat
 		},
 		variables: { playlistID, shareID },
 	})
+}
+
+export const useUpdateSongMutation = (
+	song: IScopedSong,
+	playlistID?: string,
+	opts?: IMutationOptions<IUpdateSongData>,
+) => {
+	const updateSongCache = useMemo(() => makeUpdateSongCache(song.libraryID, playlistID), [song.libraryID, playlistID])
+
+	const mutation = useMutation(UPDATE_SONG, { ...opts, update: updateSongCache })
+
+	return mutation
 }

--- a/projects/frontend/src/graphql/mutations/update-song-mutation.ts
+++ b/projects/frontend/src/graphql/mutations/update-song-mutation.ts
@@ -56,6 +56,7 @@ const makeUpdateSongCache = (shareID: string, playlistID?: string): MutationUpda
 		)
 	}
 
+	// share song is automatically updated by apollo
 	if (!playlistID) return
 
 	const currentPlaylist = cache.readQuery<IGetPlaylistSongsData, IGetPlaylistSongsVariables>({
@@ -85,7 +86,7 @@ export const useUpdateSongMutation = (
 	playlistID?: string,
 	opts?: IMutationOptions<IUpdateSongData>,
 ) => {
-	const updateSongCache = useMemo(() => makeUpdateSongCache(song.libraryID, playlistID), [song.libraryID, playlistID])
+	const updateSongCache = useMemo(() => makeUpdateSongCache(song.shareID, playlistID), [song.shareID, playlistID])
 
 	const mutation = useMutation(UPDATE_SONG, { ...opts, update: updateSongCache })
 


### PR DESCRIPTION
* refactor move update song mutation to custom hook
* fix invariant error on song update cache via `shareID` of scoped song
* replace `IMutationOptions` with apollo's `MutationHookOptions` type
* replace and remove song-modal.css