### PR TITLE
backend: switch docker base image to buster slim

### DIFF
--- a/projects/backend/Dockerfile
+++ b/projects/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:current-buster-slim
 
 # Create app directory
 RUN mkdir -p /usr/src/app
@@ -6,9 +6,7 @@ WORKDIR /usr/src/app
 
 COPY ./ /usr/src/app/
 
-RUN apk add --no-cache make gcc g++ python && \
-	npm install --silent && \
-	apk del make gcc g++ python
+RUN	npm install --silent
 
 RUN npx lerna bootstrap --scope @musicshare/backend --include-dependencies
 RUN npx lerna run build --scope @musicshare/backend --include-dependencies


### PR DESCRIPTION
Since we recently ran into some database connectivity issues due to [DNS problems](https://github.com/gliderlabs/docker-alpine/blob/master/docs/caveats.md) caused by the underlying alpine image, we now switch to the buster slim base image.
Docker image size difference is only +63MB.