### PR TITLE
fix: frontend improve player performance during playback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33257,6 +33257,14 @@
 				"lottie-web": "^5.1.3"
 			}
 		},
+		"react-page-visibility": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/react-page-visibility/-/react-page-visibility-6.2.0.tgz",
+			"integrity": "sha512-jCXAMx+8tioRoviWuaJqcAfu3DzQ3JBQBUn0KoneTQ0FQqMSpNWU4VbUuyVm9+i8+8T0beeDv1aV7VZq280vBA==",
+			"requires": {
+				"prop-types": "^15.7.2"
+			}
+		},
 		"react-router": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10105,9 +10105,9 @@
 			}
 		},
 		"@types/jest": {
-			"version": "26.0.7",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.7.tgz",
-			"integrity": "sha512-+x0077/LoN6MjqBcVOe1y9dpryWnfDZ+Xfo3EqGeBcfPRJlQp3Lw62RvNlWxuGv7kOEwlHriAa54updi3Jvvwg==",
+			"version": "26.0.8",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.8.tgz",
+			"integrity": "sha512-eo3VX9jGASSuv680D4VQ89UmuLZneNxv2MCZjfwlInav05zXVJTzfc//lavdV0GPwSxsXJTy2jALscB7Acqg0g==",
 			"dev": true,
 			"requires": {
 				"jest-diff": "^25.2.1",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
 		"react-dom": "^16.8.6",
 		"react-dropzone": "^11.0.1",
 		"react-lottie": "^1.2.3",
+		"react-page-visibility": "^6.2.0",
 		"react-router-dom": "^5.0.0",
 		"react-virtualized": "^9.21.2",
 		"reflect-metadata": "^0.1.13",

--- a/projects/frontend/src/App.tsx
+++ b/projects/frontend/src/App.tsx
@@ -61,7 +61,7 @@ const theme: IPrimaryTheme = {
 	darkgrey: "#474350",
 }
 
-const App = () => {
+export const App = () => {
 	return (
 		<>
 			<GlobalStyle />
@@ -81,5 +81,3 @@ const App = () => {
 		</>
 	)
 }
-
-export default App

--- a/projects/frontend/src/components/player/SongQueue.tsx
+++ b/projects/frontend/src/components/player/SongQueue.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback } from "react"
 import { OrderedListOutlined } from "@ant-design/icons"
 import { Popover, Button, Empty } from "antd"
-import { usePlayerQueue } from "../../player/player-hook"
 import { SongQueueItem } from "./SongQueueItem"
 import Scrollbars from "react-custom-scrollbars"
 import styled from "styled-components"
+import { IPlayerQueueItem } from "./player-state"
 
 const TitleContainer = styled.div`
 	display: flex;
@@ -18,9 +18,13 @@ const ClearButton = styled.div`
 	font-size: 12px;
 `
 
-export const SongQueue: React.FC = () => {
-	const { queue, setSongQueue, clearQueue } = usePlayerQueue()
+interface ISongQueueProps {
+	queue: IPlayerQueueItem[]
+	setSongQueue: (items: IPlayerQueueItem[]) => void
+	clearQueue: () => void
+}
 
+export const SongQueue: React.FC<ISongQueueProps> = React.memo(({ queue, setSongQueue, clearQueue }) => {
 	const moveItem = useCallback(
 		(dragIndex: number, hoverIndex: number) => {
 			if (dragIndex === hoverIndex) return
@@ -68,4 +72,4 @@ export const SongQueue: React.FC = () => {
 			<Button icon={<OrderedListOutlined />} type="link" size="large" style={{ color: "white" }} />
 		</Popover>
 	)
-}
+})

--- a/projects/frontend/src/components/player/player-state.ts
+++ b/projects/frontend/src/components/player/player-state.ts
@@ -240,7 +240,7 @@ const setPlayerQueue: ResolverFn<ISetPlayerQueueVariables, ISetPlayerQueueData> 
 
 		return items
 	}
-	console.log("items", items)
+
 	cache.writeQuery<IGetPlayerQueueStateData, void>({
 		query: GET_PLAYER_QUEUE_STATE,
 		data: {

--- a/projects/frontend/src/components/sidebar/PlaylistsSidebar.tsx
+++ b/projects/frontend/src/components/sidebar/PlaylistsSidebar.tsx
@@ -42,9 +42,9 @@ interface IPlaylistSidebar {
 	merged: boolean
 }
 
-export const PlaylistSidebar: React.FC<IPlaylistSidebar> = ({ merged }) => {
+export const PlaylistSidebar: React.FC<IPlaylistSidebar> = React.memo(({ merged }) => {
 	return <Sidebar>{merged ? <MergedPlaylistsSidebar /> : <SharePlaylistsSidebar />}</Sidebar>
-}
+})
 
 const SharePlaylistsSidebar = () => {
 	const {

--- a/projects/frontend/src/components/song-table/SongRow.tsx
+++ b/projects/frontend/src/components/song-table/SongRow.tsx
@@ -1,7 +1,7 @@
-import React, { useRef, useEffect } from "react"
+import React, { useRef, useEffect, useMemo } from "react"
 import { ListRowProps } from "react-virtualized"
 import { IRowEvents } from "./SongTable"
-import { DragElementWrapper, DragPreviewOptions, DragPreviewImage, useDrop } from "react-dnd"
+import { DragElementWrapper, DragPreviewOptions, DragPreviewImage, useDrop, DropTargetHookSpec } from "react-dnd"
 import { Row, Col } from "./SongTableUI"
 import songDragPreviewImg from "../../images/playlist_add.png"
 import { DragNDropItem, ISongDNDItem } from "../../types/DragNDropItems"
@@ -37,16 +37,21 @@ export const SongRow: React.FC<ISongRowProps> = ({
 	const songsViewContext = useSongsViewContext()
 	const { columns, songs } = songsViewContext[0]
 
-	const [{ isOver }, drop] = useDrop<ISongDNDItem, void, { isOver: boolean }>({
-		accept: DragNDropItem.Song,
-		canDrop: () => isPlaylist,
-		collect: (monitor) => ({ isOver: isPlaylist && monitor.isOver() }),
-		drop: (item) => {
-			if (moveSong) {
-				moveSong(item.song, song)
-			}
-		},
-	})
+	const useDropOpts = useMemo<DropTargetHookSpec<ISongDNDItem, void, { isOver: boolean }>>(
+		() => ({
+			accept: DragNDropItem.Song,
+			canDrop: () => isPlaylist,
+			collect: (monitor) => ({ isOver: isPlaylist && monitor.isOver() }),
+			drop: (item) => {
+				if (moveSong) {
+					moveSong(item.song, song)
+				}
+			},
+		}),
+		[isPlaylist, moveSong, song],
+	)
+
+	const [{ isOver }, drop] = useDrop<ISongDNDItem, void, { isOver: boolean }>(useDropOpts)
 
 	useEffect(() => {
 		if (rowRef.current) {

--- a/projects/frontend/src/components/song-table/SongTable.tsx
+++ b/projects/frontend/src/components/song-table/SongTable.tsx
@@ -64,15 +64,6 @@ export const SongTable: React.FC<ISongDataTableProps> = React.memo(
 			item: { type: DragNDropItem.Song, song: hoveredSong!, idx: hoveredIdx },
 		})
 
-		//const onContextMenu = useCa
-
-		useEffect(() => {
-			console.log("rowEvents changed")
-		}, [rowEvents])
-		useEffect(() => {
-			console.log("showContextMenu changed")
-		}, [showContextMenu])
-
 		const hookedRowEvents = useMemo(
 			(): IRowEvents => ({
 				...rowEvents,

--- a/projects/frontend/src/components/song-table/SongTable.tsx
+++ b/projects/frontend/src/components/song-table/SongTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useCallback, useState, useEffect, useRef } from "react"
 import { List, ListRowProps, AutoSizer } from "react-virtualized"
 import { useContextMenu } from "../modals/contextmenu/ContextMenu"
 import { SongContextMenu, ISongContextMenuEvents } from "../../pages/share/SongContextMenu"
-import { useDrag } from "react-dnd"
+import { useDrag, DragElementWrapper, DragPreviewOptions } from "react-dnd"
 import { DragNDropItem, ISongDNDItem } from "../../types/DragNDropItems"
 import { isMutableRef } from "../../types/isMutableRef"
 import { Empty } from "antd"
@@ -10,7 +10,7 @@ import { useEventListener } from "../../hooks/use-event-listener"
 import { SongRow } from "./SongRow"
 import { Table, Header, HeaderCol, Body } from "./SongTableUI"
 import { MoveSong } from "./MoveSong"
-import { useCalculatedColumnWidths } from "./SongTableColumns"
+import { useCalculatedColumnWidths, CalculatedColumnWidths } from "./SongTableColumns"
 import Scrollbars from "react-custom-scrollbars"
 import styled from "styled-components"
 import { useSongsViewContext } from "./SongsView"
@@ -48,144 +48,185 @@ interface ISongDataTableProps {
 	moveSong?: MoveSong
 }
 
-export const SongTable: React.FC<ISongDataTableProps> = ({ rowEvents, playlistID, contextMenuEvents, moveSong }) => {
-	const [
-		{ songs, columns, hoveredSong, hoveredIdx, sortColumn, sortOrder },
-		{ setHoveredSong, setOrderCriteria },
-	] = useSongsViewContext()
-	const enableOrdering = !playlistID
-	const { showContextMenu, isVisible: contextMenuVisible, ref: contextMenuRef } = useContextMenu()
-	const [height, setHeight] = useState(0)
-	const bodyRef = useRef<HTMLDivElement>(null)
-	const calculatedColumnWidths = useCalculatedColumnWidths(columns)
+export const SongTable: React.FC<ISongDataTableProps> = React.memo(
+	({ rowEvents, playlistID, contextMenuEvents, moveSong }) => {
+		const [
+			{ songs, columns, hoveredSong, hoveredIdx, sortColumn, sortOrder },
+			{ setHoveredSong, setOrderCriteria },
+		] = useSongsViewContext()
+		const enableOrdering = !playlistID
+		const { showContextMenu, isVisible: contextMenuVisible, ref: contextMenuRef } = useContextMenu()
+		const [height, setHeight] = useState(0)
+		const bodyRef = useRef<HTMLDivElement>(null)
+		const calculatedColumnWidths = useCalculatedColumnWidths(columns)
 
-	const [, drag, dragPreview] = useDrag<ISongDNDItem, void, {}>({
-		item: { type: DragNDropItem.Song, song: hoveredSong!, idx: hoveredIdx },
-	})
+		const [, drag, dragPreview] = useDrag<ISongDNDItem, void, {}>({
+			item: { type: DragNDropItem.Song, song: hoveredSong!, idx: hoveredIdx },
+		})
 
-	const hookedRowEvents = useMemo(
-		(): IRowEvents => ({
-			...rowEvents,
-			onContextMenu: ({ event, song, idx, songs }) => {
-				if (rowEvents.onContextMenu) {
-					rowEvents.onContextMenu({ event, song, idx, songs })
+		//const onContextMenu = useCa
+
+		useEffect(() => {
+			console.log("rowEvents changed")
+		}, [rowEvents])
+		useEffect(() => {
+			console.log("showContextMenu changed")
+		}, [showContextMenu])
+
+		const hookedRowEvents = useMemo(
+			(): IRowEvents => ({
+				...rowEvents,
+				onContextMenu: ({ event, song, idx, songs }) => {
+					if (rowEvents.onContextMenu) {
+						rowEvents.onContextMenu({ event, song, idx, songs })
+					}
+
+					showContextMenu(event)
+				},
+			}),
+			[rowEvents, showContextMenu],
+		)
+
+		const onRowMouseEnter = useCallback(
+			(song: Song, ref: React.Ref<HTMLDivElement>, idx: number) => {
+				if (!contextMenuVisible) {
+					setHoveredSong(song, idx)
 				}
 
-				showContextMenu(event)
+				if (isMutableRef(ref)) {
+					drag(ref.current)
+				}
 			},
-		}),
-		[rowEvents, showContextMenu],
-	)
+			[setHoveredSong, contextMenuVisible, drag],
+		)
 
-	const onRowMouseEnter = useCallback(
-		(song: Song, ref: React.Ref<HTMLDivElement>, idx: number) => {
-			if (!contextMenuVisible) {
-				setHoveredSong(song, idx)
-			}
-
-			if (isMutableRef(ref)) {
-				drag(ref.current)
-			}
-		},
-		[setHoveredSong, contextMenuVisible, drag],
-	)
-
-	const rowRenderer = useCallback(
-		(props: ListRowProps) => {
-			const song = songs[props.index]
-
-			return (
-				<SongRow
-					{...props}
-					song={song}
+		const rowRenderer = useCallback(
+			(props: ListRowProps) => (
+				<SongRowRenderer
+					songs={songs}
 					rowEvents={hookedRowEvents}
-					hovered={hoveredSong === song}
-					onMouseEnter={(e, ref) => onRowMouseEnter(song, ref, props.index)}
+					hoveredSong={hoveredSong}
+					onRowMouseEnter={onRowMouseEnter}
 					dragPreview={dragPreview}
 					moveSong={moveSong}
-					isPlaylist={playlistID !== undefined}
+					playlistID={playlistID}
 					calculatedColumnWidths={calculatedColumnWidths}
+					{...props}
 				/>
-			)
-		},
-		[
-			hoveredSong,
-			hookedRowEvents,
-			songs,
-			dragPreview,
-			onRowMouseEnter,
-			moveSong,
-			playlistID,
-			calculatedColumnWidths,
-		],
-	)
+			),
+			[
+				hoveredSong,
+				hookedRowEvents,
+				songs,
+				dragPreview,
+				onRowMouseEnter,
+				moveSong,
+				playlistID,
+				calculatedColumnWidths,
+			],
+		)
 
-	const evaluateAndSetHeight = useCallback(() => {
-		if (bodyRef.current) {
-			setHeight(bodyRef.current.clientHeight)
-		}
-	}, [bodyRef, setHeight])
+		const evaluateAndSetHeight = useCallback(() => {
+			if (bodyRef.current) {
+				setHeight(bodyRef.current.clientHeight)
+			}
+		}, [bodyRef, setHeight])
 
-	useEffect(evaluateAndSetHeight, [evaluateAndSetHeight])
+		useEffect(evaluateAndSetHeight, [evaluateAndSetHeight])
 
-	useEventListener(
-		"resize",
-		() => {
-			evaluateAndSetHeight()
-		},
-		window,
-	)
+		useEventListener(
+			"resize",
+			() => {
+				evaluateAndSetHeight()
+			},
+			window,
+		)
 
-	return (
-		<Table>
-			<Header>
-				{columns.map((column) => (
-					<HeaderCol
-						key={column.title}
-						style={{
-							width: calculatedColumnWidths[column.key],
-							flexShrink: column.fixWidth ? 0 : undefined,
-						}}
-						onClick={
-							enableOrdering && column.sortable
-								? () => setOrderCriteria(column.key, toggleDirection(sortOrder))
-								: undefined
-						}
-						selected={enableOrdering && sortColumn === column.key}
-						direction={sortOrder}
-					>
-						{column.title}
-					</HeaderCol>
-				))}
-			</Header>
-			<Body ref={bodyRef}>
-				<StyledScrollbars autoHide>
-					<AutoSizer disableHeight>
-						{({ width }) => (
-							<List
-								height={height}
-								overscanRowCount={100}
-								noRowsRenderer={() => (
-									<Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No songs" />
-								)}
-								rowCount={songs.length}
-								rowHeight={27}
-								rowRenderer={rowRenderer}
-								width={width}
-								style={{ outline: 0 }}
-							/>
-						)}
-					</AutoSizer>
-				</StyledScrollbars>
-			</Body>
+		return (
+			<Table>
+				<Header>
+					{columns.map((column) => (
+						<HeaderCol
+							key={column.title}
+							style={{
+								width: calculatedColumnWidths[column.key],
+								flexShrink: column.fixWidth ? 0 : undefined,
+							}}
+							onClick={
+								enableOrdering && column.sortable
+									? () => setOrderCriteria(column.key, toggleDirection(sortOrder))
+									: undefined
+							}
+							selected={enableOrdering && sortColumn === column.key}
+							direction={sortOrder}
+						>
+							{column.title}
+						</HeaderCol>
+					))}
+				</Header>
+				<Body ref={bodyRef}>
+					<StyledScrollbars autoHide>
+						<AutoSizer disableHeight>
+							{({ width }) => (
+								<List
+									height={height}
+									overscanRowCount={100}
+									noRowsRenderer={() => (
+										<Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No songs" />
+									)}
+									rowCount={songs.length}
+									rowHeight={27}
+									rowRenderer={rowRenderer}
+									width={width}
+									style={{ outline: 0 }}
+								/>
+							)}
+						</AutoSizer>
+					</StyledScrollbars>
+				</Body>
 
-			<SongContextMenu
-				song={hoveredSong}
-				playlistID={playlistID}
-				ref={contextMenuRef}
-				events={contextMenuEvents}
-				contextMenuVisible={contextMenuVisible}
-			/>
-		</Table>
-	)
+				<SongContextMenu
+					song={hoveredSong}
+					playlistID={playlistID}
+					ref={contextMenuRef}
+					events={contextMenuEvents}
+					contextMenuVisible={contextMenuVisible}
+				/>
+			</Table>
+		)
+	},
+)
+
+interface ISongRowRendererProps extends ListRowProps {
+	songs: IShareSong[]
+	rowEvents: IRowEvents
+	hoveredSong: IShareSong | null
+	onRowMouseEnter: (song: Song, ref: React.Ref<HTMLDivElement>, idx: number) => void
+	dragPreview: DragElementWrapper<DragPreviewOptions>
+	moveSong?: MoveSong | undefined
+	playlistID: string | undefined
+	calculatedColumnWidths: CalculatedColumnWidths
 }
+
+const SongRowRenderer: React.FC<ISongRowRendererProps> = React.memo(
+	({ songs, hoveredSong, playlistID, onRowMouseEnter, ...props }) => {
+		const song = songs[props.index]
+
+		const onMouseEnter = useCallback(
+			(event: React.MouseEvent<HTMLDivElement, MouseEvent>, ref: React.Ref<HTMLDivElement>) => {
+				onRowMouseEnter(song, ref, props.index)
+			},
+			[onRowMouseEnter, song, props.index],
+		)
+
+		return (
+			<SongRow
+				{...props}
+				song={song}
+				hovered={hoveredSong === song}
+				onMouseEnter={onMouseEnter}
+				isPlaylist={playlistID !== undefined}
+			/>
+		)
+	},
+)

--- a/projects/frontend/src/components/song-table/SongTableHeader.tsx
+++ b/projects/frontend/src/components/song-table/SongTableHeader.tsx
@@ -39,34 +39,31 @@ interface ISongTableHeaderProps {
 	onSongViewSettingsChange: (newSettings: ISongViewSettings) => void
 }
 
-export const SongTableHeader = ({
-	songs,
-	title,
-	onSearchFilterChange,
-	onSongViewSettingsChange,
-}: ISongTableHeaderProps) => {
-	const { changeSong } = usePlayerActions()
-	const { open: triggerUploadModal } = useSongDropzone()
+export const SongTableHeader = React.memo(
+	({ songs, title, onSearchFilterChange, onSongViewSettingsChange }: ISongTableHeaderProps) => {
+		const { changeSong } = usePlayerActions()
+		const { open: triggerUploadModal } = useSongDropzone()
 
-	const durationSum = songs.reduce((acc, song) => acc + song.duration, 0)
+		const durationSum = songs.reduce((acc, song) => acc + song.duration, 0)
 
-	const onClickSong = (song: IShareSong) => {
-		changeSong(song)
-	}
+		const onClickSong = (song: IShareSong) => {
+			changeSong(song)
+		}
 
-	return (
-		<SongTableHeaderFlexContainer>
-			<MetaInfoContainer>
-				<Title level={4} style={{ marginBottom: 0 }}>
-					{title}
-				</Title>
-				<Text>
-					{songs.length} songs | {formatDuration(durationSum)}
-				</Text>
-			</MetaInfoContainer>
-			<HeaderButton icon={<ArrowUpOutlined />} onClick={triggerUploadModal} title="Upload" />
-			<SongViewSettings onChange={onSongViewSettingsChange} />
-			<SongSearch onClickSong={onClickSong} onSearchFilterChange={onSearchFilterChange} />
-		</SongTableHeaderFlexContainer>
-	)
-}
+		return (
+			<SongTableHeaderFlexContainer>
+				<MetaInfoContainer>
+					<Title level={4} style={{ marginBottom: 0 }}>
+						{title}
+					</Title>
+					<Text>
+						{songs.length} songs | {formatDuration(durationSum)}
+					</Text>
+				</MetaInfoContainer>
+				<HeaderButton icon={<ArrowUpOutlined />} onClick={triggerUploadModal} title="Upload" />
+				<SongViewSettings onChange={onSongViewSettingsChange} />
+				<SongSearch onClickSong={onClickSong} onSearchFilterChange={onSearchFilterChange} />
+			</SongTableHeaderFlexContainer>
+		)
+	},
+)

--- a/projects/frontend/src/hooks/use-updated-value-if.ts
+++ b/projects/frontend/src/hooks/use-updated-value-if.ts
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from "react"
+
+export function useUpdatedValueIf<T>(value: T, condition: boolean) {
+	const currentValue = useRef(value)
+
+	useEffect(() => {
+		if (condition) {
+			currentValue.current = value
+		}
+	}, [value, condition])
+
+	return currentValue.current
+}

--- a/projects/frontend/src/index.tsx
+++ b/projects/frontend/src/index.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import ReactDOM from "react-dom"
-import App from "./App"
+import { App } from "./App"
 import * as serviceWorker from "./serviceWorker"
 
 ReactDOM.render(<App />, document.getElementById("root"))

--- a/projects/frontend/src/pages/share/MainSongsView.tsx
+++ b/projects/frontend/src/pages/share/MainSongsView.tsx
@@ -131,6 +131,14 @@ export const MainSongsView: React.FC<ISongsViewProps> = ({ title, songs, playlis
 		return mappedSongTableColumns
 	}, [playlistID, customColumns, isMergedView])
 
+	const rowEvents = useMemo(
+		() => ({
+			onClick: onRowClick,
+			onDoubleClick: onRowDoubleClick,
+		}),
+		[onRowClick, onRowDoubleClick],
+	)
+
 	return (
 		<FlexContainer>
 			<SongsView
@@ -151,10 +159,7 @@ export const MainSongsView: React.FC<ISongsViewProps> = ({ title, songs, playlis
 						/>
 						<TableContainer>
 							<SongTable
-								rowEvents={{
-									onClick: onRowClick,
-									onDoubleClick: onRowDoubleClick,
-								}}
+								rowEvents={rowEvents}
 								contextMenuEvents={{
 									onShowInformation: (song) => {
 										setEditSong(song)

--- a/projects/frontend/src/pages/share/Share.tsx
+++ b/projects/frontend/src/pages/share/Share.tsx
@@ -24,7 +24,7 @@ const UpdatePlaylistID: React.FC = ({ children }) => {
 	return <>{children}</>
 }
 
-export const Share = () => {
+export const Share = React.memo(() => {
 	const { shareID } = useParams<IShareRoute>()
 	const match = useRouteMatch()
 	useUpdateShareID(shareID)
@@ -44,4 +44,4 @@ export const Share = () => {
 			<Route path="/shares/:shareID" exact render={() => <ShareSongs />} />
 		</>
 	)
-}
+})

--- a/projects/frontend/src/typings/react-page-visibility.d.ts
+++ b/projects/frontend/src/typings/react-page-visibility.d.ts
@@ -1,0 +1,3 @@
+declare module "react-page-visibility" {
+	export const usePageVisibility: () => boolean
+}


### PR DESCRIPTION
* App component use named export
* don't re-render song rows if player playback state changes
* player memorize constant parts and only render player updates if tab is active
* debounce primary deck time and buffering update callbacks